### PR TITLE
[FIX] Permanent driver number not matching results

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1414,9 +1414,7 @@ class Session:
 
         time0 = None
         for r in data:
-            d['DriverNumber'].append(
-                recursive_dict_get(r, 'Driver', 'permanentNumber',
-                                   default_none=True))
+            d['DriverNumber'].append(r.get('number'))
             if load_drivers:
                 d['Abbreviation'].append(
                     recursive_dict_get(r, 'Driver', 'code',


### PR DESCRIPTION
**Behavior**
When loading the qualifying results or race results from the 2022 season it doesn't show the lap times and position data of Max Verstappen in the `session.results`

**Expected behavior**
Max Verstappen should be in the right position and include the position and lap times  in the `session.results`.

**How to reproduce**
```python
import fastf1 as ff1

session = ff1.get_session(2022, 'Bahrein Grand Prix', 'Q')
session.load()

print(session.results)
```

**Fix information**
The Ergast API sends back both the Driver number as permanent number in the `Driver` section of the result, but the current number will be provided as attribute of the result itself.

As Max Verstappen has changed his driver number from 33 to 1 for this season the number used later for the timing data doesn't match.

```xml
<QualifyingResult number="1" position="2">
	<Driver driverId="max_verstappen" code="VER" url="http://en.wikipedia.org/wiki/Max_Verstappen">
		<PermanentNumber>33</PermanentNumber>
		...
	</Driver>
	...
</QualifyingResult>
```
