### PR TITLE
Switch to pure flake8 and add pre-commit ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,9 +87,27 @@ jobs:
           python3 -m pip install -e .
 
       - name: Run tests
+        if: ${{ github.ref != 'refs/heads/master' }}
         run: |
           mkdir test_cache  # make sure cache dir exists
-          pytest -rf --flake8 --lint-only
+          git fetch origin --quiet
+          # flake8 with default config
+          flake8 fastf1 examples scripts
+          # flake8 check new shorter line length only on diff
+          git diff origin/master -U0 --relative | flake8 --max-line-length 79 --diff --select E501 fastf1 examples scripts
+
+      - name: Run tests (master push)
+        if: ${{ github.ref == 'refs/heads/master' && env.GITHUB_EVENT_NAME == 'push'}}
+        env:
+          LAST_PUSH_SHA: ${{ github.event.before }}
+        run: |
+          mkdir test_cache  # make sure cache dir exists
+          git fetch origin --quiet
+          # flake8 with default config
+          flake8 fastf1 examples scripts
+          # flake8 check new shorter line length only on diff
+          echo "Flake8 line length check on diff against $LAST_PUSH_SHA"
+          git diff $LAST_PUSH_SHA -U0 --relative | flake8 --max-line-length 79 --diff --select E501 fastf1 examples scripts
 
 
   run-readme-render-test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: flake8-line-length
+        name: Flake8 line length
+        entry: python ./scripts/flake8_line_length.py
+        language: python

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -133,12 +133,18 @@ rules before submitting a pull request:
   <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`_.
 
 * Formatting should follow the recommendations of PEP8_, as enforced by
-  flake8_.  You can check flake8 compliance from the command line with ::
+  flake8_. The maximum line length for all changed lines is 79 characters.
+  You can check flake8 compliance from the command line with ::
 
-    python -m pip install pytest pytest-flake8
-    pytest --flake8 --lint-only
+    python -m pip install flake8
+    flake8 fastf1 examples
 
-  or your editor may provide integration with it.
+  or your editor may provide integration with it. The above command will not
+  flag lines that are too long!
+
+  Flake8 will also be run before each commit if you have the pre-commit hooks
+  installed (see :ref:`install_pre_commit`). Contrary to the manual invocation of flake8, this will also flag
+  lines which are too long!
 
   .. _PEP8: https://www.python.org/dev/peps/pep-0008/
   .. _flake8: https://flake8.pycqa.org/

--- a/docs/contributing/devenv_setup.rst
+++ b/docs/contributing/devenv_setup.rst
@@ -54,17 +54,17 @@ environment so that Python will be able to import FastF1 from your
 development source directory. This allows you to import your modified version
 of FastF1 without re-installing after every change.
 
-..
-  TODO: add section once pre-commit hooks are added
-  Installing pre-commit hooks
-  ===========================
-  You can optionally install `pre-commit <https://pre-commit.com/>`_ hooks.
-  These will automatically check flake8 and other style issues when you run
-  ``git commit``. The hooks are defined in the top level
-  ``.pre-commit-config.yaml`` file. To install the hooks ::
+.. _install_pre_commit:
 
-      pip install pre-commit
-      pre-commit install
+Installing pre-commit hooks
+===========================
+You can optionally install `pre-commit <https://pre-commit.com/>`_ hooks.
+These will automatically check flake8 and other style issues when you run
+``git commit``. The hooks are defined in the top level
+``.pre-commit-config.yaml`` file. To install the hooks ::
+
+    pip install pre-commit
+    pre-commit install
 
 Installing additional dependencies for development
 ==================================================

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,6 @@ sphinx-gallery
 autodocsumm
 wheel
 flake8==3.9.2
-pytest-flake8
 readme-renderer
 xdoctest
+pre-commit

--- a/scripts/flake8_line_length.py
+++ b/scripts/flake8_line_length.py
@@ -1,0 +1,18 @@
+"""This script will run flake8 but only check for then new line length limit of
+79 characters. The checks are limited to the currently staged changes."""
+import os
+import subprocess
+import sys
+
+print(os.getcwd())
+
+
+p_diff = subprocess.Popen(["git", "diff", "--cached", "-U0", "--relative"],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+p_flake8 = subprocess.Popen(["flake8", "--max-line-length", "79",
+                             "--select", "E501", "--diff",
+                             "fastf1 examples scripts"],
+                            stdin=p_diff.stdout)
+p_flake8.wait()
+sys.exit(p_flake8.returncode)


### PR DESCRIPTION
Use flake8 directly instead of pytest --flake8

Add pre-commit hook for flake8 and add pre-commit CI. This allows to enforce a different line length limit on new/changed code in pull requests compared to the whole repository. Reasons is, that we want to transition from a 120 character line length to 79 character line length.