### PR TITLE
Draft: Fix #165: session.laps.pick_fastest() should return the overall faste…

### DIFF
--- a/docs/examples/basics.rst
+++ b/docs/examples/basics.rst
@@ -299,8 +299,8 @@ The following data columns are available:
   Index(['Time', 'DriverNumber', 'LapTime', 'LapNumber', 'Stint', 'PitOutTime',
          'PitInTime', 'Sector1Time', 'Sector2Time', 'Sector3Time',
          'Sector1SessionTime', 'Sector2SessionTime', 'Sector3SessionTime',
-         'SpeedI1', 'SpeedI2', 'SpeedFL', 'SpeedST', 'IsPersonalBest',
-         'Compound', 'TyreLife', 'FreshTyre', 'LapStartTime', 'Team', 'Driver',
+         'SpeedI1', 'SpeedI2', 'SpeedFL', 'SpeedST', 'isCurrentSessionPersonalBest',
+         'historicalPersonalBest','Compound', 'TyreLife', 'FreshTyre', 'LapStartTime', 'Team', 'Driver',
          'TrackStatus', 'IsAccurate', 'LapStartDate'],
         dtype='object')
 

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1196,7 +1196,8 @@ class Session:
                     result['NumberOfLaps'] = 0
                     result['NumberOfPitStops'] = 0
                     result['Time'] = data['Time'].min()
-                    result['IsPersonalBest'] = False
+                    result['isCurrentSessionPersonalBest'] = False
+                    result['historicalPersonalBest'] = False
                     result['Compound'] = d2['Compound'].iloc[0]
                     result['TotalLaps'] = d2['TotalLaps'].iloc[0]
                     result['New'] = d2['New'].iloc[0]
@@ -2051,8 +2052,8 @@ class Laps(pd.DataFrame):
         if only_by_time:
             laps = self  # all laps
         else:
-            # select only laps marked as personal fastest
-            laps = self.loc[self['IsPersonalBest'] == True]  # noqa: E712 comparison with True
+            # get all personal best records across sessions
+            laps = self.loc[self['historicalPersonalBest'] == True]  # noqa: E712,E501 comparison with True
 
         if not laps.size:
             return Lap(index=self.columns)


### PR DESCRIPTION
…st lap, instead of the fastest lap in the latest session.

The personal best lap times are now additionally tracked in another column, 'historicalPersonalBest' which will let us pull the fastest legal lap across all sessions for any given event.