### PR TITLE
Add get_events_remaining function

### DIFF
--- a/fastf1/__init__.py
+++ b/fastf1/__init__.py
@@ -17,6 +17,7 @@ session. This can be done with one of the following functions:
     fastf1.get_session
     fastf1.get_testing_session
     fastf1.get_event
+    fastf1.get_events_remaining
     fastf1.get_testing_session
     fastf1.get_event_schedule
 
@@ -49,6 +50,7 @@ Events API
 .. autofunction:: get_session
 .. autofunction:: get_testing_session
 .. autofunction:: get_event
+.. autofunction:: get_events_remaining
 .. autofunction:: get_testing_event
 .. autofunction:: get_event_schedule
 
@@ -63,6 +65,7 @@ Cache API
 from fastf1.events import (get_session,  # noqa: F401
                            get_testing_session,
                            get_event,
+                           get_events_remaining,
                            get_testing_event,
                            get_event_schedule)
 

--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -388,6 +388,32 @@ def get_event_schedule(year, *, include_testing=True, force_ergast=False):
     return schedule
 
 
+def get_events_remaining(
+        dt=None, *, include_testing=True, force_ergast=False) \
+        -> 'EventSchedule':
+    """Create an :class:`~fastf1.events.EventSchedule` object for remaining season.
+
+    Args:
+        dt (datetime): Optional DateTime to get events after.
+        include_testing (bool): Include or exclude testing sessions from the
+            event schedule.
+        force_ergast (bool): Always use data from the ergast database to
+            create the event schedule
+
+    Returns:
+        :class:`~fastf1.events.EventSchedule`
+
+    .. versionadded:: 2.3
+    """
+    if dt is None:
+        dt = datetime.datetime.now()
+
+    events = get_event_schedule(
+        dt.year, include_testing=include_testing, force_ergast=force_ergast)
+    result = events.loc[events["EventDate"] >= dt]
+    return result
+
+
 def _get_schedule(year):
     response = Cache.requests_get(
         _SCHEDULE_BASE_URL + f"schedule_{year}.json"

--- a/fastf1/tests/test_events.py
+++ b/fastf1/tests/test_events.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pandas as pd
 import pytest
 
@@ -51,6 +53,25 @@ def test_get_testing_session(test_n, session_n, pass_1, pass_2):
     else:
         with pytest.raises(ValueError):
             fastf1.get_testing_session(2021, test_n, session_n)
+
+
+@pytest.mark.parametrize("dt", [datetime.datetime(year=2022, month=6, day=1)])
+def test_get_events_remaining(dt):
+    events = fastf1.get_events_remaining(dt)
+    assert len(events) == 15
+
+
+@pytest.mark.parametrize("dt",
+                         [datetime.datetime(year=2022, month=12, day=31)])
+def test_events_remaining_after_season(dt):
+    events = fastf1.get_events_remaining(dt)
+    assert len(events) == 0
+
+
+@pytest.mark.parametrize("dt", [datetime.datetime(year=2022, month=1, day=1)])
+def test_events_remaining_before_season(dt):
+    events = fastf1.get_events_remaining(dt)
+    assert len(events) == 24
 
 
 @pytest.mark.parametrize("gp", ['Bahrain', 'Bharain', 'Sakhir', 1])


### PR DESCRIPTION
Suggesting a useful helper function `get_events_remaining` which returns the remaining events for the season. I was doing some experimentation and thought this could be a useful for me and maybe for others.