### PR TITLE
Add support for shorthand paths in Cache.enable_cache

### DIFF
--- a/fastf1/api.py
+++ b/fastf1/api.py
@@ -129,6 +129,9 @@ class Cache:
             force_renew (bool): Ignore existing cached data. Download data and update the cache instead.
             use_requests_cache (bool): Do caching of the raw GET and POST requests.
         """
+        # Allow users to use paths such as ~user or ~/
+        cache_dir = os.path.expanduser(cache_dir)
+
         if not os.path.exists(cache_dir):
             raise NotADirectoryError("Cache directory does not exist! Please check for typos or create it first.")
         cls._CACHE_DIR = cache_dir


### PR DESCRIPTION
Adds support for `~/` and `~username` when enabling cache. 

With this change this works:
```
$ python
Python 3.10.4 (main, Jun 29 2022, 12:14:53) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import fastf1
>>> fastf1.Cache.enable_cache("~/.f1")
>>> session = fastf1.get_session(2020, 13, 'FP1')
>>> session.load(laps=True, telemetry=False, weather=False)
core           INFO 	Loading data for Emilia Romagna Grand Prix - Practice 1 [v2.2.9]
api            INFO 	No cached data found for driver_info. Loading data...
api            INFO 	Fetching driver list...
api            INFO 	Data has been written to cache!
(....)
```

Without it `fastf1.Cache.enable_cache("~/.f1")` doesn't work because `os.path.exists(cache_dir)` doesn't expand and will throw an exception even if the folder actually exists:

```
>>> fastf1.Cache.enable_cache("~/.f1")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/oscar/repo/Fast-F1/fastf1/api.py", line 136, in enable_cache
    raise NotADirectoryError("Cache directory does not exist! Please check for typos or create it first.")
NotADirectoryError: Cache directory does not exist! Please check for typos or create it first.
```