### PR TITLE
Add drivers standings. Improve example.

### DIFF
--- a/examples/plot_who_can_still_win_wdc.py
+++ b/examples/plot_who_can_still_win_wdc.py
@@ -4,26 +4,13 @@
 Calculates which drivers still has chance to win the WDC.
 Simplified since it doesn't compare positions if points are equal.
 
-This example implements 3 functions that it then uses to calculate
-it's result.
+This example implements 2 functions that it then uses to calculate
+its result.
 """
 
-import requests
 import fastf1
 
 fastf1.Cache.enable_cache("../doc_cache")  # replace with your cache directory
-
-
-##############################################################################
-# We need a function to get the current driver standings from
-# Ergast and returns as list of drivers.
-# Reference https://ergast.com/mrd/methods/standings/
-def get_drivers_standings():
-    url = "https://ergast.com/api/f1/current/driverStandings.json"
-    response = requests.get(url)
-    data = response.json()
-    drivers_standings = data['MRData']['StandingsTable']['StandingsLists'][0]['DriverStandings']  # noqa: E501
-    return drivers_standings
 
 
 ##############################################################################
@@ -70,11 +57,13 @@ Can win: {can_win}")
 
 
 ##############################################################################
-# Now using the 3 functions above we can use them to calculate who
+# Now using the 2 functions above we can use them to calculate who
 # can still win.
 
-# Get the current drivers standings
-driver_standings = get_drivers_standings()
+# We need a function to get the current driver standings from
+# Ergast and returns as list of drivers.
+# Reference https://ergast.com/mrd/methods/standings/
+driver_standings = fastf1.get_driver_standings(2022)
 
 # Get the maximum amount of points
 points = calculate_max_points_for_remaining_season()

--- a/examples/plot_who_can_still_win_wdc.py
+++ b/examples/plot_who_can_still_win_wdc.py
@@ -43,14 +43,14 @@ def calculate_max_points_for_remaining_season():
 # We currently don't consider the case of two drivers getting equal points
 # since its more complicated and would require comparing positions.
 def calculate_who_can_win(driver_standings, max_points):
-    LEADER_POINTS = int(driver_standings[0]['points'])
+    LEADER_POINTS = int(driver_standings['points'].iat[0])
 
-    for _, driver in enumerate(driver_standings):
+    for _, driver in driver_standings.iterrows():
         driver_max_points = int(driver["points"]) + max_points
         can_win = 'No' if driver_max_points < LEADER_POINTS else 'Yes'
 
         print(f"{driver['position']}: \
-{driver['Driver']['code']}, \
+{driver['Driver_code']}, \
 Current points: {driver['points']}, \
 Theoretical max points: {driver_max_points}, \
 Can win: {can_win}")

--- a/fastf1/__init__.py
+++ b/fastf1/__init__.py
@@ -69,9 +69,10 @@ from fastf1.events import (get_session,  # noqa: F401
                            get_testing_event,
                            get_event_schedule)
 
+
 from fastf1.api import Cache  # noqa: F401
 from fastf1.version import __version__   # noqa: F401
-
+from fastf1.ergast import get_driver_standings  # noqa: F401
 
 _DRIVER_TEAM_MAPPING = {
     # only necessary when loading live timing data that does not include

--- a/fastf1/ergast.py
+++ b/fastf1/ergast.py
@@ -1,4 +1,5 @@
 import json
+import pandas
 import warnings
 
 from fastf1.api import Cache
@@ -8,17 +9,20 @@ base_url = 'https://ergast.com/api/f1'
 _headers = {'User-Agent': f'FastF1/{__version__}'}
 
 
-def get_driver_standings(year="current"):
+def get_driver_standings(year="current") -> pandas.DataFrame:
     """
-    Returns dre
+    Returns driver standings
     :param year:
-    :return:
+    :return: DataFrame
     """
     url = f"https://ergast.com/api/f1/{year}/driverStandings.json"
-    return _parse_ergast_driver_standings(
-        _parse_json_response(
-            Cache.requests_get(url, headers=_headers)
-        )
+    return pandas.json_normalize(
+        _parse_ergast_driver_standings(
+            _parse_json_response(
+                Cache.requests_get(url, headers=_headers)
+            )
+        ),
+        sep='_'
     )
 
 

--- a/fastf1/ergast.py
+++ b/fastf1/ergast.py
@@ -8,6 +8,24 @@ base_url = 'https://ergast.com/api/f1'
 _headers = {'User-Agent': f'FastF1/{__version__}'}
 
 
+def get_driver_standings(year="current"):
+    """
+    Returns dre
+    :param year:
+    :return:
+    """
+    url = f"https://ergast.com/api/f1/{year}/driverStandings.json"
+    return _parse_ergast_driver_standings(
+        _parse_json_response(
+            Cache.requests_get(url, headers=_headers)
+        )
+    )
+
+
+def _parse_ergast_driver_standings(data):
+    return data['MRData']['StandingsTable']['StandingsLists'][0]['DriverStandings']  # noqa: E501
+
+
 def fetch_results(year, gp, session):
     """session can be 'Qualifying' or 'Race'
     mainly to port on upper level libraries


### PR DESCRIPTION
Part of #229 

I experimented a little with making it a pandas Dataframe but it was kind of tricky with the (standings response)[http://ergast.com/mrd/methods/standings/]. Both that we want a very strict subset of the response `data['MRData']['StandingsTable']['StandingsLists'][0]['DriverStandings']`, but still then the data is a list of dicts with nested dicts (such as Driver and Constructors). 

I tried to flatten the DF. I tried variants `pandas.DataFrame.from_dict()` etc but didn't I didn't get it a into a nice format. Another thought that I had was: even if I manage to make it a Dataframe. Will the `calculate_who_can_win` function be better with it? Would those types of calculations be improved?