### PR TITLE
Implement default cache location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,6 @@ Hamilton for the Turkish GP 2020.
 
     plotting.setup_mpl()
 
-    fastf1.Cache.enable_cache('path/to/folder/for/cache')  # optional but recommended
-
     race = fastf1.get_session(2020, 'Turkish Grand Prix', 'R')
     race.load()
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,13 +31,8 @@ visualization.
 
 FastF1 handles big chunks of data (~50-100mb per session). To improve performance
 data is per default cached locally as requests (be aware). The default placement
-of the cache is operating system specific:
-
-  - Windows: `%LOCALAPPDATA%\Temp\fastf1`
-  - macOS: `~/Library/Caches/fastf1`
-  - Linux: `~/.cache/fastf1` if `~/.cache` exists otherwise `~/.fastf1`
-
-You can override the default location by using `Cache.enable_cache('location')`.
+of the cache is operating system specific. A custom location can be set if desired.
+For more information see :class:`~fastf1.api.Cache`.
 
 All data is downloaded from two sources:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,8 +29,15 @@ The module is designed around Pandas, Numpy and Matplotlib. This makes it easy
 to use while offering lots of possibilities for data analysis and
 visualization.
 
-FastF1 handles big chunks of data (~50-100mb per session) so most of the
-information is stored locally as cached requests (be aware).
+FastF1 handles big chunks of data (~50-100mb per session). To improve performance
+data is per default cached locally as requests (be aware). The default placement
+of the cache is operating system specific:
+
+  - Windows: `%LOCALAPPDATA%\Temp\fastf1`
+  - macOS: `~/Library/Caches/fastf1`
+  - Linux: `~/.cache/fastf1` if `~/.cache` exists otherwise `~/.fastf1`
+
+You can override the default location by using `Cache.enable_cache('location')`.
 
 All data is downloaded from two sources:
 

--- a/fastf1/api.py
+++ b/fastf1/api.py
@@ -348,7 +348,7 @@ class Cache:
                     try:
                         os.mkdir(cache_dir, mode=0o0700)
                     except Exception as err:
-                        logging.error("Failed to create cache directory {0}. Error {1}".format(cache_dir, err))
+                        logging.error("Failed to create cache directory {0}. Error {1}".format(cache_dir, err))  # noqa: E501
                         raise
 
                 # Enable cache with default

--- a/fastf1/api.py
+++ b/fastf1/api.py
@@ -105,6 +105,10 @@ class Cache:
         >>> session = fastf1.get_session(2021, 5, 'Q')
         >>> # ...
 
+    An alternative way to set the cache directory is to configure an
+    environment variable `FASTF1_CACHE`. However, this value will be
+    ignored if `Cache.enable_cache()` is called.
+
     If no explicit location is provied, Fast-F1 will use a default location
     depending on operating system.
 

--- a/fastf1/api.py
+++ b/fastf1/api.py
@@ -112,7 +112,7 @@ class Cache:
     If no explicit location is provied, Fast-F1 will use a default location
     depending on operating system.
 
-        - Windows: `%LOCALAPPDATA%\\Temp\\fastf1`
+        - Windows: `%LOCALAPPDATA%\\\\Temp\\\\fastf1`
         - macOS: `~/Library/Caches/fastf1`
         - Linux: `~/.cache/fastf1` if `~/.cache` exists otherwise `~/.fastf1`
 

--- a/fastf1/api.py
+++ b/fastf1/api.py
@@ -81,14 +81,13 @@ pages = {
 class Cache:
     """Pickle and requests based API cache.
 
+    Fast-F1 will per default enable caching. While this can be disabled, it
+    should almost always be enabled to speed up the runtime of your scripts
+    and to prevent exceeding the rate limit of api servers.
+
     The parsed API data will be saved as a pickled object.
     Raw GET requests are cached in a sqlite db using the 'requests-cache'
     module.
-
-    Caching should almost always be enabled to speed up the runtime of your
-    scripts and to prevent exceeding the rate limit of api servers.
-    FastF1 will print an annoyingly obnoxious warning message if you do not
-    enable caching.
 
     The cache has two "stages".
 
@@ -98,7 +97,7 @@ class Cache:
           running your scripts,  as parsing of the data is computationally
           expensive. Stage 2 caching is only used for some api functions.
 
-    Most commonly, you will enable caching right at the beginning of your script:
+    You can explicitly configure right at the beginning of your script:
 
         >>> import fastf1
         >>> fastf1.Cache.enable_cache('path/to/cache')  # doctest: +SKIP
@@ -106,9 +105,16 @@ class Cache:
         >>> session = fastf1.get_session(2021, 5, 'Q')
         >>> # ...
 
-    Note that you should always enable caching except for very rare
-    circumstances which are usually limited to doing core developement
-    on FastF1.
+    If no explicit location is provied, Fast-F1 will use a default location
+    depending on operating system.
+
+        - Windows: `%LOCALAPPDATA%\\Temp\\fastf1`
+        - macOS: `~/Library/Caches/fastf1`
+        - Linux: `~/.cache/fastf1` if `~/.cache` exists otherwise `~/.fastf1`
+
+    Cached data can be deleted at any time to reclaim disk space. However,
+    this also means you will have to redownload the same data again if you
+    need which will lead to reduced performance.
     """
     _CACHE_DIR = ''
     # version of the api parser code (unrelated to release version number)


### PR DESCRIPTION
Here is a draft for a possible solution for #234. 

I've added the big operating systems for now, but it can easily be expanded. I've ensure that if you enable cache yourself it isn't activated and if we don't recognize the platform it won't trigger.

On a machine without the cache folder existing it looks like this.

```
python3
Python 3.10.4 (main, Jun 29 2022, 12:14:53) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import fastf1
>>> session = fastf1.get_session(2022, 13, 'Q')
api         WARNING 	

DEFAULT CACHE ENABLED!
	Cache directory: /home/oscaru/.cache/fastf1.
	Size: 20.0 KB
```

After I've loaded a session. The next time I start fastf1 I will get the size. 

```
python3
Python 3.10.4 (main, Jun 29 2022, 12:14:53) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import fastf1
>>> session = fastf1.get_session(2022, 13, 'Q')
api         WARNING 	

DEFAULT CACHE ENABLED!
	Cache directory: /home/oscaru/.cache/fastf1.
	Size: 46.12 MB
```

If I explicitly enable caching then default caching won't active:

```
python3
Python 3.10.4 (main, Jun 29 2022, 12:14:53) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import fastf1
>>> fastf1.Cache.enable_cache("~/.fastf1")
>>> session = fastf1.get_session(2022, 13, 'Q')
>>> 
```

What do you think about this general approach?