### PR TITLE
fix: Update gitignore to ignore Python venv files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,16 @@ exp*.py
 venv/
 act/
 .actrc
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json
 
 # build output directories
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ act/
 [Ll]ib64
 [Ll]ocal
 [Ss]cripts
+[Ss]hare
 pyvenv.cfg
 .venv
 pip-selfcheck.json

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ act/
 [Ll]ib
 [Ll]ib64
 [Ll]ocal
-[Ss]cripts
 [Ss]hare
 pyvenv.cfg
 .venv


### PR DESCRIPTION
## Changes

Added the following files/folders to `.gitignore`:

```gitignore
.Python
[Bb]in
[Ii]nclude
[Ll]ib
[Ll]ib64
[Ll]ocal
[Ss]cripts
pyvenv.cfg
.venv
pip-selfcheck.json
```

## Fixes

Fixes #261 