### PR TITLE
Fix clear cache when using default cache

### DIFF
--- a/fastf1/api.py
+++ b/fastf1/api.py
@@ -196,8 +196,9 @@ class Cache:
     def clear_cache(cls, cache_dir=None, deep=False):
         """Clear all cached data.
 
-        Deletes all files in the cache directory. By default, it will clear the default cache directory.
-        However, if a cache directory is provided as an argument this will be cleared instead. Optionally,
+        Deletes all files in the cache directory. By default, it will clear
+        the default cache directory. However, if a cache directory is
+        provided as an argument this will be cleared instead. Optionally,
         the requests cache can be cleared too.
 
         Can be called without enabling the cache first.

--- a/fastf1/api.py
+++ b/fastf1/api.py
@@ -196,8 +196,9 @@ class Cache:
     def clear_cache(cls, cache_dir=None, deep=False):
         """Clear all cached data.
 
-        This deletes all cache files in the provided cache directory.
-        Optionally, the requests cache is cleared too.
+        Deletes all files in the cache directory. By default, it will clear the default cache directory.
+        However, if a cache directory is provided as an argument this will be cleared instead. Optionally,
+        the requests cache can be cleared too.
 
         Can be called without enabling the cache first.
 


### PR DESCRIPTION
Improves the `clear_cache` function

* Argument `cache_dir` is now optional.
* It doesn't fail with relative paths anymore `~/.fastf1`
* It clears the default path if no cache_dir is provided to the function

Fixes #271 

Example usage
```
python3
Python 3.10.6 (main, Aug 10 2022, 11:40:04) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import fastf1
>>> fastf1.api.Cache.clear_cache()
>>> session = fastf1.get_session(2021, 'Spanish Grand Prix', 'Q')
api         WARNING 	

DEFAULT CACHE ENABLED!
	Cache directory: /home/oscar/.cache/fastf1.
	Size: 7.63 MB
>>> session.load()
core           INFO 	Loading data for Spanish Grand Prix - Qualifying [v2.3.0]
api            INFO 	No cached data found for driver_info. Loading data...
api            INFO 	Fetching driver list...
api            INFO 	Data has been written to cache!
api            INFO 	No cached data found for timing_data. Loading data...
api            INFO 	Fetching timing data...
api            INFO 	Parsing timing data...
api            INFO 	Data has been written to cache!
api            INFO 	No cached data found for timing_app_data. Loading data...
api            INFO 	Fetching timing app data...
api            INFO 	Data has been written to cache!
core           INFO 	Processing timing data...
api            INFO 	No cached data found for session_status_data. Loading data...
api            INFO 	Fetching session status data...
api            INFO 	Data has been written to cache!
api            INFO 	No cached data found for track_status_data. Loading data...
api            INFO 	Fetching track status data...
api            INFO 	Data has been written to cache!
api            INFO 	No cached data found for car_data. Loading data...
api            INFO 	Fetching car data...
api            INFO 	Parsing car data...
api            INFO 	Data has been written to cache!
api            INFO 	No cached data found for position_data. Loading data...
api            INFO 	Fetching position data...
api            INFO 	Parsing position data...
api            INFO 	Data has been written to cache!
api            INFO 	No cached data found for weather_data. Loading data...
api            INFO 	Fetching weather data...
api            INFO 	Data has been written to cache!
api            INFO 	No cached data found for race_control_messages. Loading data...
api            INFO 	Fetching race control messages...
api            INFO 	Data has been written to cache!
core           INFO 	Finished loading data for 20 drivers: ['44', '33', '77', '16', '31', '55', '3', '11', '4', '14', '18', '10', '5', '99', '63', '22', '7', '47', '6', '9']
>>> fastf1.api.Cache.get_default_cache_path()
'~/.cache/fastf1'
>>> import os
>>> cache_dir = fastf1.api.Cache.get_default_cache_path()
>>> cache_dir = os.path.expandvars(cache_dir)
>>> cache_dir = os.path.expanduser(cache_dir)
>>> fastf1.api.Cache._get_size(cache_dir)
60721287
>>> fastf1.api.Cache.clear_cache()
>>> fastf1.api.Cache._get_size(cache_dir)
8003584
```