### PR TITLE
changes on pick_fastest

### DIFF
--- a/examples/example_pick_fastest.py
+++ b/examples/example_pick_fastest.py
@@ -1,0 +1,8 @@
+import fastf1
+fastf1.Cache.enable_cache('D:/f1/f1py/cache') 
+s=fastf1.get_session(2022,"austrian Grand Prix","Q")
+s.load(messages=True)
+
+
+print(s.laps.pick_driver("ALB").pick_fastest("Q1"))# 1:06:516 to  compare check https://www.fia.com/sites/default/files/2022_11_aut_f1_q0_timing_qualifyingsessionlaptimes_v01.pdf  
+                                                   # tecnically fastest in Q1 was 1:06:511 but was deleted

--- a/fastf1/tests/test_core.py
+++ b/fastf1/tests/test_core.py
@@ -32,3 +32,11 @@ def test_laps_constructor_metadata_propagation(reference_laps_data):
     assert laps.session is session
     assert laps.iloc[0:2].session is session
     assert laps.iloc[0].session is session
+
+def test_pick_fastest_Not_InQ3():
+    s=fastf1.get_session(2022,"Austrian GP","Q")
+    s.load()
+    expectlaptime="1:06.330"
+    lap=s.laps.pick_driver("NOR").pick_fastest()#no args
+    lapString=fastf1.core.Lap.lapTimetoString(lap)
+    assert expectlaptime == lapString


### PR DESCRIPTION

About the changes:
-`pick_fastest()` (without arguments) now returns the oficially fastest lap of the driver, no matter the qualifying round.
If you really want to know which was the fastest of Q_n_ round, you can call pick_fastest("Q1") so the fastest lap of only that round would be returned, since that is the only round that would be taken into account.

-To verify that the lap was not deleted I created the method` Lap.isValid()` that compares that lap with the race control messages and checks if it was deleted due to track limits

-I was able to get qualifying rounds (Q1,Q2 and Q3) thanks to the session status data. The method` Session.get_quali_rounds()` returns a dictionary with the timestamps of beginning and end of each Q1 Q2 and Q3

I don't know if this was exactly what you were looking for, but as far as I am concerned it works pretty decent, but some tests need to be made.

I left appart the isPersonalBest attribute since I didn't figure out how it worked.

I know that the code have been written in a more "correct" way, but this is just the beginning.
Please, feel free to have a look at it and tell me what you think about it!

P.S: I've tried to create the new virtual environment (venv) and now just 3 files have changed, so it looks better compared to the previous PR. However, _Include_ and _sripts_ folder are still in my project structure and I don't know if they should be. (as you described in the now closed PR #275 