### PR TITLE
Added new function for adding track status data to `Telemetry`

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -755,7 +755,7 @@ class Telemetry(pd.DataFrame):
             ts.extend([statuses[index]] * dd_shape)
 
         dd_shape = d[(d['Date'] > events.iloc[-1])].shape[0]
-        ts.extend([statuses[index]] * dd_shape)
+        ts.extend([statuses[-1]] * dd_shape)
 
         d['TrackStatus'] = ts
         return d

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -755,7 +755,7 @@ class Telemetry(pd.DataFrame):
             ts.extend([statuses[index]] * dd_shape)
 
         dd_shape = d[(d['Date'] > events.iloc[-1])].shape[0]
-        ts.extend([statuses[-1]] * dd_shape)
+        ts.extend([statuses.iloc[-1]] * dd_shape)
 
         d['TrackStatus'] = ts
         return d

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -719,9 +719,11 @@ class Telemetry(pd.DataFrame):
         See :func:`fastf1.api.track_status_data` for more information.
 
         Args:
-            drop_existing (bool): Drop and recalculate column if it already exists
+            drop_existing (bool): Drop and recalculate column if it already
+                exists.
         Returns:
-            :class:`Telemetry`: self joined with new column or self if column exists and `drop_existing` is False.
+            :class:`Telemetry`: self joined with new column or self if column
+                exists and `drop_existing` is False.
         """
         if 'TrackStatus' in self.columns:
             if drop_existing:
@@ -735,15 +737,16 @@ class Telemetry(pd.DataFrame):
         statuses = d.session.track_status['Status']
         events = d.session.t0_date + d.session.track_status['Time']
 
-        # |------ Track Status event K ------|------ N telemetry samples ------|------ Track Status event K + 1 ------|
-        #                                                    ^
-        #                                            all samples have the
-        #                                          same Track Status event K
+        # |--- event K ---|--- N telemetry samples ---|--- event K + 1 ---|
+        #                           ^
+        #                   all samples have the same
+        #                 track status because of event K
         #
         # For each track status event, calculate the in between events of the
         # telemetry, up until the next track status event. For each of the in
-        # between events add the corresponding track status to an array. At last,
-        # create the new column 'TrackStatus' with the array of track statuses.
+        # between events add the corresponding track status to an array. At
+        # last, create the new column 'TrackStatus' with the array of track
+        # statuses.
         for index in range(events.shape[0] - 1):
             curr_e = events[index]
             next_e = events[index+1]

--- a/fastf1/tests/test_telemetry.py
+++ b/fastf1/tests/test_telemetry.py
@@ -302,7 +302,7 @@ def test_add_track_status():
     # rainy and short session, good for fast test/quick loading
     session = fastf1.get_session(2020, 5, 'FP2')
 
-     # load the data
+    # load the data
     session.load(telemetry=True)
     test_data = session.laps.pick_driver('VER').get_telemetry()
     test_data = test_data.add_track_status()

--- a/fastf1/tests/test_telemetry.py
+++ b/fastf1/tests/test_telemetry.py
@@ -316,7 +316,6 @@ def test_add_track_status():
     assert test_data['TrackStatus'].iloc[-1] == statuses.iloc[-1]
 
 
-
 def create_sample_car_data():
     # create sample telemetry for testing the .add_* methods
     # which work with distance, only time and speed really needs

--- a/fastf1/tests/test_telemetry.py
+++ b/fastf1/tests/test_telemetry.py
@@ -298,6 +298,25 @@ def test_add_driver_ahead_resampled(reference_laps_data):
     assert test_data['DistanceToDriverAhead'].isnull().sum() <= 1
 
 
+def test_add_track_status():
+    # rainy and short session, good for fast test/quick loading
+    session = fastf1.get_session(2020, 5, 'FP2')
+
+     # load the data
+    session.load(telemetry=True)
+    test_data = session.laps.pick_driver('VER').get_telemetry()
+    test_data = test_data.add_track_status()
+
+    # Get statuses
+    statuses = session.track_status['Status']
+
+    # First and last track statuses must be equal to first and last
+    # statuses
+    assert test_data['TrackStatus'].iloc[0] == statuses.iloc[0]
+    assert test_data['TrackStatus'].iloc[-1] == statuses.iloc[-1]
+
+
+
 def create_sample_car_data():
     # create sample telemetry for testing the .add_* methods
     # which work with distance, only time and speed really needs

--- a/fastf1/tests/test_telemetry.py
+++ b/fastf1/tests/test_telemetry.py
@@ -298,13 +298,11 @@ def test_add_driver_ahead_resampled(reference_laps_data):
     assert test_data['DistanceToDriverAhead'].isnull().sum() <= 1
 
 
-def test_add_track_status():
-    # rainy and short session, good for fast test/quick loading
-    session = fastf1.get_session(2020, 5, 'FP2')
+@pytest.mark.f1telapi
+def test_add_track_status(reference_laps_data):
+    session, laps = reference_laps_data
 
-    # load the data
-    session.load(telemetry=True)
-    test_data = session.laps.pick_driver('VER').get_telemetry()
+    test_data = laps.pick_driver('VER').get_telemetry()
     test_data = test_data.add_track_status()
 
     # Get statuses


### PR DESCRIPTION
There is now a function to add a `TrackStatus` column to an existing `Telemetry` object. This function only adds the track status number and not the corresponding track status message.