### PR TITLE
fix: correct documentation for WeatherData.WindSpeed

### DIFF
--- a/fastf1/api.py
+++ b/fastf1/api.py
@@ -1681,7 +1681,7 @@ def weather_data(path, response=None, livedata=None):
         - Rainfall (bool): Shows if there is rainfall
         - TrackTemp (float): Track temperature [°C]
         - WindDirection (int): Wind direction [°] (0°-359°)
-        - WindSpeed (float): Wind speed [km/h]
+        - WindSpeed (float): Wind speed [m/s]
 
     Weather data is updated once per minute.
 


### PR DESCRIPTION
Confirmed that the weather data is actually m/s. Comparing it to the data channel in F1TV it's always the value for km/h shown, divided by 3.6, so the values in the data streams are actually m/s.