### PR TITLE
[DOC] Clarify cache requirements for testing and doc build

### DIFF
--- a/docs/contributing/devenv_setup.rst
+++ b/docs/contributing/devenv_setup.rst
@@ -56,7 +56,14 @@ of FastF1 without re-installing after every change.
 
 .. _install_pre_commit:
 
-Installing pre-commit hooks
+Installing additional dependencies for development
+==================================================
+To install additional dependencies for development, testing and building of the
+documentation, run the following command within the :file:`Fast-F1` directory::
+
+    python -m pip install -r requirements-dev.txt
+
+[Optional] Installing pre-commit hooks
 ===========================
 You can optionally install `pre-commit <https://pre-commit.com/>`_ hooks.
 These will automatically check flake8 and other style issues when you run
@@ -65,10 +72,3 @@ These will automatically check flake8 and other style issues when you run
 
     pip install pre-commit
     pre-commit install
-
-Installing additional dependencies for development
-==================================================
-To install additional dependencies for development, testing and building of the
-documentation, run the following command within the :file:`Fast-F1` directory::
-
-    python -m pip install -r requirements-dev.txt

--- a/docs/contributing/devenv_setup.rst
+++ b/docs/contributing/devenv_setup.rst
@@ -64,7 +64,7 @@ documentation, run the following command within the :file:`Fast-F1` directory::
     python -m pip install -r requirements-dev.txt
 
 [Optional] Installing pre-commit hooks
-===========================
+======================================
 You can optionally install `pre-commit <https://pre-commit.com/>`_ hooks.
 These will automatically check flake8 and other style issues when you run
 ``git commit``. The hooks are defined in the top level

--- a/docs/contributing/documenting_fastf1.rst
+++ b/docs/contributing/documenting_fastf1.rst
@@ -22,9 +22,7 @@ The documentation for FastF1 is generated from reStructuredText (ReST_)
 using the Sphinx_ documentation generation tool.
 
 To build the documentation you will need to
-:ref:`set up FastF1 for development <installing_for_devs>`. Note in
-particular the additional dependencies required to
-build the documentation.
+:ref:`set up FastF1 for development <installing_for_devs>`.
 
 Building the docs
 -----------------
@@ -38,6 +36,9 @@ from the project root directory:
 .. code:: sh
 
   python setup.py build_sphinx
+
+
+The documentation build expects the cache directory :file:`doc_cache/` to exist. You will have to create it the first time.
 
 
 The generated documentation can be found in :file:`docs/_build/html` and viewed

--- a/docs/contributing/testing.rst
+++ b/docs/contributing/testing.rst
@@ -19,8 +19,7 @@ Requirements
 ------------
 
 To run the tests you will need to
-:ref:`set up FastF1 for development <installing_for_devs>`. Note in
-particular the additional dependencies for testing.
+:ref:`set up FastF1 for development <installing_for_devs>`.
 
 
 Running the tests
@@ -29,6 +28,9 @@ Running the tests
 In the root directory of your development repository run::
 
    python -m pytest
+
+
+pytest expects the cache directory :file:`test_cache/` to exist. You will have to create it the first time.
 
 
 pytest can be configured via a lot of `command-line parameters`_. Some


### PR DESCRIPTION
I was playing around with building Fast-F1, and found a couple of places in the contributing section of the documentation that may be confusing:

* the 'Writing documentation' page suggests to "Note in particular the additional dependencies required to build the documentation", right after linking to the 'Setting up FastF1 for development' page, but I couldn't find anything in that page about additional dependencies for building the doc, and I managed to build it just fine. I removed this mention as it doesn't seem to point to anything (anymore?)
* same thing on the 'Testing' page
* to build the documentation, users first need to create a `doc_cache` directory at the root of the repo. I added a sentence to that effect in the 'Writing documentation' page
* similarly, for testing, a directory named `test_cache` is expected. I added a sentence to that effect in the testing page