### PR TITLE
Add HeadshotUrl and CountryCode fields to session results and driver info

### DIFF
--- a/docs/examples/basics.rst
+++ b/docs/examples/basics.rst
@@ -234,7 +234,7 @@ functionality to speed up data loading and to prevent excessive API requests.
   18           18      L STROLL          STR  ...  NaT           NaN
   22           22     Y TSUNODA          TSU  ...  NaT           NaN
   <BLANKLINE>
-  [20 rows x 17 columns]
+  [20 rows x 18 columns]
 
 The results object (:class:`fastf1.core.SessionResults`) is a subclass of a
 :class:`pandas.DataFrame`. Therefore, we can take a look at what data columns
@@ -242,9 +242,9 @@ there are:
 
   >>> session.results.columns  # doctest: +NORMALIZE_WHITESPACE
   Index(['DriverNumber', 'BroadcastName', 'Abbreviation', 'TeamName',
-         'TeamColor', 'FirstName', 'LastName', 'FullName', 'HeadshotUrl',
-         'Position', 'GridPosition', 'Q1', 'Q2', 'Q3', 'Time', 'Status', 
-         'Points'],
+         'TeamColor', 'FirstName', 'LastName', 'FullName', 'HeadshotUrl', 
+         'CountryCode', 'Position', 'GridPosition', 'Q1', 'Q2', 'Q3', 'Time', 
+         'Status', 'Points'],
         dtype='object')
 
 As an example, lets display the top ten drivers and their

--- a/docs/examples/basics.rst
+++ b/docs/examples/basics.rst
@@ -234,7 +234,7 @@ functionality to speed up data loading and to prevent excessive API requests.
   18           18      L STROLL          STR  ...  NaT           NaN
   22           22     Y TSUNODA          TSU  ...  NaT           NaN
   <BLANKLINE>
-  [20 rows x 16 columns]
+  [20 rows x 17 columns]
 
 The results object (:class:`fastf1.core.SessionResults`) is a subclass of a
 :class:`pandas.DataFrame`. Therefore, we can take a look at what data columns
@@ -242,8 +242,9 @@ there are:
 
   >>> session.results.columns  # doctest: +NORMALIZE_WHITESPACE
   Index(['DriverNumber', 'BroadcastName', 'Abbreviation', 'TeamName',
-         'TeamColor', 'FirstName', 'LastName', 'FullName', 'Position',
-         'GridPosition', 'Q1', 'Q2', 'Q3', 'Time', 'Status', 'Points'],
+         'TeamColor', 'FirstName', 'LastName', 'FullName', 'HeadshotUrl',
+         'Position', 'GridPosition', 'Q1', 'Q2', 'Q3', 'Time', 'Status', 
+         'Points'],
         dtype='object')
 
 As an example, lets display the top ten drivers and their

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1797,7 +1797,8 @@ class Session:
                 'BroadcastName': 'BroadcastName',
                 'Tla': 'Abbreviation', 'TeamName': 'TeamName',
                 'TeamColour': 'TeamColor', 'FirstName': 'FirstName',
-                'LastName': 'LastName', 'HeadshotUrl': 'HeadshotUrl'
+                'LastName': 'LastName', 'HeadshotUrl': 'HeadshotUrl',
+                'CountryCode': 'CountryCode'
             }.items():
                 for entry in f1di.values():
                     driver_info[key2].append(entry.get(key1))
@@ -2839,6 +2840,9 @@ class SessionResults(pd.DataFrame):
         - ``HeadshotUrl`` | :class:`str` |
           The URL to the driver's headshot
 
+        - ``CountryCode`` | :class:`str` |
+          The driver's country code (e.g. "FRA")
+
         - ``Position`` | :class:`float` |
           The drivers finishing position (values only given if session is
           'Race', 'Qualifying' or 'Sprint Qualifying')
@@ -2901,6 +2905,7 @@ class SessionResults(pd.DataFrame):
         'LastName': str,
         'FullName': str,
         'HeadshotUrl': str,
+        'CountryCode': str,
         'Position': 'float64',
         'GridPosition': 'float64',
         'Q1': 'timedelta64[ns]',

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1797,7 +1797,7 @@ class Session:
                 'BroadcastName': 'BroadcastName',
                 'Tla': 'Abbreviation', 'TeamName': 'TeamName',
                 'TeamColour': 'TeamColor', 'FirstName': 'FirstName',
-                'LastName': 'LastName'
+                'LastName': 'LastName', 'HeadshotUrl': 'HeadshotUrl'
             }.items():
                 for entry in f1di.values():
                     driver_info[key2].append(entry.get(key1))
@@ -2836,6 +2836,9 @@ class SessionResults(pd.DataFrame):
         - ``LastName`` | :class:`str` |
           The drivers last name
 
+        - ``HeadshotUrl`` | :class:`str` |
+          The URL to the driver's headshot
+
         - ``Position`` | :class:`float` |
           The drivers finishing position (values only given if session is
           'Race', 'Qualifying' or 'Sprint Qualifying')
@@ -2897,6 +2900,7 @@ class SessionResults(pd.DataFrame):
         'FirstName': str,
         'LastName': str,
         'FullName': str,
+        'HeadshotUrl': str,
         'Position': 'float64',
         'GridPosition': 'float64',
         'Q1': 'timedelta64[ns]',

--- a/fastf1/tests/test_api.py
+++ b/fastf1/tests/test_api.py
@@ -220,3 +220,26 @@ def test_lap_count_data():
     for col, dtype in zip(data.values(), dtypes):
         assert isinstance(col[0], dtype)
         assert len(col) == 57
+
+
+def test_driver_list():
+    response = list()
+    tl = 12  # length of timestamp: len('00:00:00:000')
+    with open('fastf1/testing/reference_data/'
+              '2020_05_FP2/driver_list.raw', 'rb') as fobj:
+        for line in fobj.readlines():
+            dec = line.decode('utf-8-sig')
+            response.append([dec[:tl], fastf1.api.parse(dec[tl:])])
+
+    # parse data; api path is unused here so it does not need to be valid
+    data = fastf1.api.driver_info('api/path', response=response)
+
+    # ########## verify driver data
+    assert isinstance(data, dict)
+    assert len(data.keys()) == 20
+    dtypes = [str, str, str, str, int, str, str, str, str, str, str,
+              datetime.timedelta, datetime.timedelta, datetime.timedelta,
+              datetime.timedelta, str, float]
+    for driver in data.values():
+        for col, dtype in zip(driver.values(), dtypes):
+            assert isinstance(col, dtype)


### PR DESCRIPTION
I noticed that the Headshot URL doesn't show up in the driver info dataframe, even if it's available.
This PR adds it, as well as a small test for `driver_list`