### PR TITLE
Add compound colors dict, minor docstring rewrite

### DIFF
--- a/fastf1/plotting.py
+++ b/fastf1/plotting.py
@@ -84,7 +84,7 @@ TEAM_COLORS = __TeamColorsWarnDict({
     'alfa romeo': '#900000', 'alphatauri': '#2b4562',
     'haas': '#ffffff', 'williams': '#005aff'
 })
-"""Mapping of team colors (hex color code) to team names.
+"""Mapping of team names to team colors (hex color codes).
 (current season only)"""
 
 TEAM_TRANSLATE: Dict[str, str] = {
@@ -127,7 +127,7 @@ DRIVER_COLORS: Dict[str, str] = {
     "alexander albon": "#005aff",
     "logan sargeant": "#012564",
 }
-"""Mapping of driver colors (hex color code) to driver names.
+"""Mapping of driver names to driver colors (hex color codes).
 (current season only)"""
 
 DRIVER_TRANSLATE: Dict[str, str] = {
@@ -142,6 +142,17 @@ DRIVER_TRANSLATE: Dict[str, str] = {
     'HAM': 'lewis hamilton', 'RUS': 'george russell',
     'ALB': 'alexander albon', 'SAR': 'logan sargeant'}
 """Mapping of driver names to theirs respective abbreviations."""
+
+COMPOUND_COLORS: Dict[str, str] = {
+    "SOFT": "da291c",
+    "MEDIUM": "ffd12e",
+    "HARD": "f0f0ec",
+    "INTERMEDIATE": "43b02a",
+    "WET": "0067ad",
+    "UNKNOWN": "00ffff",
+}
+"""Mapping of tyre compound names to compound colors (hex color codes).
+(current season only)"""
 
 COLOR_PALETTE: List[str] = ['#FF79C6', '#50FA7B', '#8BE9FD', '#BD93F9',
                             '#FFB86C', '#FF5555', '#F1FA8C']


### PR DESCRIPTION
I got an email that you assigned this issue to a milestone so I assumed you want it to be worked on.

The process is not very rigorous. I found the tyre icons' image files used on the F1 live timing page and got the color codes from there.

- Soft: [`da291c`](https://www.color-hex.com/color/da291c)
- Medium: [`ffd12e`](https://www.color-hex.com/color/ffd12e)
- Hard: [`f0f03c`](https://www.color-hex.com/color/f0f0ec)
- Intermediate: [`43b02a`](https://www.color-hex.com/color/43b02a)
- Wet: [`0067ad`](https://www.color-hex.com/color/0067ad)

Sometimes the data will have the color compound as `UNKNOWN` (this column is never null). I am representing this as [cyan](https://www.color-hex.com/color/00ffff) which should be clearly distinguishable from the rest.