### PR TITLE
fix(#360): add direct dep python-dateutil

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
   scipy
   thefuzz
   matplotlib>=3.3.3
+  python-dateutil
   timple>=0.1.2
   requests>=2.28.0
   websockets>=8.1


### PR DESCRIPTION
Adds python-dateutil to dependencies since it's directly imported