### PR TITLE
Improve support for Sprint Shootout format

### DIFF
--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -95,6 +95,7 @@ Event Schedule
 
 - 'conventional': Practice 1, Practice 2, Practice 3, Qualifying, Race
 - 'sprint': Practice 1, Qualifying, Practice 2, Sprint, Race
+- 'sprint_shootout': Practice 1, Qualifying, Sprint Shootout, Sprint, Race
 - 'testing': no fixed session order; usually three practice sessions on
   three separate days
 
@@ -616,7 +617,10 @@ def _get_schedule_from_f1_timing(year):
             if event['Sessions'][3]['Name'] == 'Sprint Qualifying':
                 # fix for 2021 where Sprint was called Sprint Qualifying
                 event['Sessions'][3]['Name'] = 'Sprint'
-            data['EventFormat'].append('sprint')
+            if event['Sessions'][2]['Name'] == 'Sprint Shootout':
+                data['EventFormat'].append('sprint_shootout')
+            else:
+                data['EventFormat'].append('sprint')
             data['RoundNumber'].append(event['Number'])
         elif 'test' in event['Name'].lower():
             data['EventFormat'].append('testing')
@@ -682,14 +686,17 @@ def _get_schedule_from_ergast(year) -> "EventSchedule":
         data['EventDate'].append(date)
 
         if 'Sprint' in rnd:
-            data['EventFormat'].append("sprint")
+            # Ergast doesn't support sprint shootout format yet
+            data['EventFormat'].append(
+                "sprint_shootout" if year == 2023 else "sprint")
             data['Session1'].append('Practice 1')
             data['Session1DateUtc'].append(
                 date.floor('D') - pd.Timedelta(days=2))
             data['Session2'].append('Qualifying')
             data['Session2DateUtc'].append(
                 date.floor('D') - pd.Timedelta(days=2))
-            data['Session3'].append('Practice 2')
+            data['Session3'].append(
+                'Sprint Shootout' if year == 2023 else 'Practice 2')
             data['Session3DateUtc'].append(
                 date.floor('D') - pd.Timedelta(days=1))
             data['Session4'].append('Sprint')

--- a/fastf1/tests/test_laps.py
+++ b/fastf1/tests/test_laps.py
@@ -201,3 +201,32 @@ def test_calculated_quali_results():
     session._calculate_quali_like_session_results(force=True)
 
     pd.testing.assert_frame_equal(ergast_results, session.results)
+
+
+@pytest.mark.f1telapi
+def test_quali_q3_cancelled():
+    session = fastf1.get_session(2023, 2, 'Q')
+    session.load(telemetry=False, weather=False)
+
+    # Remove Q3 to simulate cancelled Q3. If a future race has a cancelled Q3,
+    # that would be a better test case. The last one was the US GP in 2015, so
+    # no lap data is available.
+    session.session_status.drop([7, 8, 9, 10], inplace=True)
+    session.results['Q3'] = pd.NaT
+
+    # Test split_qualifying_sessions()
+    q1, q2, q3 = session.laps.split_qualifying_sessions()
+
+    assert len(q1['DriverNumber'].unique()) == 20
+    assert len(q2['DriverNumber'].unique()) == 15
+    assert q3 is None
+
+    # Test _calculate_quali_like_session_results()
+    orig_results = session.results.copy()
+    session._calculate_quali_like_session_results(force=True)
+
+    pd.testing.assert_series_equal(
+        session.results['Q1'].sort_values(), orig_results['Q1'].sort_values())
+    pd.testing.assert_series_equal(
+        session.results['Q2'].sort_values(), orig_results['Q2'].sort_values())
+    assert session.results['Q3'].isna().all()

--- a/fastf1/tests/test_laps.py
+++ b/fastf1/tests/test_laps.py
@@ -176,3 +176,28 @@ def test_split_quali_laps():
     assert len(q1['DriverNumber'].unique()) == 20
     assert len(q2['DriverNumber'].unique()) == 15
     assert len(q3['DriverNumber'].unique()) == 10
+
+
+@pytest.mark.f1telapi
+def test_split_sprint_shootout_laps():
+    session = fastf1.get_session(2023, 4, 'SS')
+    session.load(telemetry=False, weather=False)
+
+    q1, q2, q3 = session.laps.split_qualifying_sessions()
+
+    assert len(q1['DriverNumber'].unique()) == 20
+
+    # Logan Sargeant was 15th in Q1 but crashed and couldn't participate in Q2
+    assert len(q2['DriverNumber'].unique()) == 14
+    assert len(q3['DriverNumber'].unique()) == 9
+
+
+@pytest.mark.f1telapi
+def test_calculated_quali_results():
+    session = fastf1.get_session(2023, 2, 'Q')
+    session.load(telemetry=False, weather=False)
+
+    ergast_results = session.results.copy()
+    session._calculate_quali_like_session_results(force=True)
+
+    pd.testing.assert_frame_equal(ergast_results, session.results)


### PR DESCRIPTION
- Defined session tuples for "race-like" (saw this nomenclature in the docs in a few spots) and "quali-like" sessions which cleans up places where those groupings of sessions are used.
- Updated docs to add `Sprint Shootout` where appropriate.
- Added `_calculate_quali_like_session_results` method to calculate quali and sprint shootout results from laps.
- Used `_calculate_quali_like_session_results` to calculate sprint shootout results since Ergast doesn't support that format yet.
- Added some logic to support `sprint_shootout` event format when loading the schedule. Ergast doesn't support it yet, so for now assuming any sprint race for 2023 should use `sprint_shootout` format.
- Added/updated some tests with sprint shootout scenarios.