### PR TITLE
Fix compound colors dictionary

### DIFF
--- a/fastf1/plotting.py
+++ b/fastf1/plotting.py
@@ -144,12 +144,12 @@ DRIVER_TRANSLATE: Dict[str, str] = {
 """Mapping of driver names to theirs respective abbreviations."""
 
 COMPOUND_COLORS: Dict[str, str] = {
-    "SOFT": "da291c",
-    "MEDIUM": "ffd12e",
-    "HARD": "f0f0ec",
-    "INTERMEDIATE": "43b02a",
-    "WET": "0067ad",
-    "UNKNOWN": "00ffff",
+    "SOFT": "#da291c",
+    "MEDIUM": "#ffd12e",
+    "HARD": "#f0f0ec",
+    "INTERMEDIATE": "#43b02a",
+    "WET": "#0067ad",
+    "UNKNOWN": "#00ffff",
 }
 """Mapping of tyre compound names to compound colors (hex color codes).
 (current season only)"""


### PR DESCRIPTION
I discovered this bug while writing an example. When seaborn ingest palettes, the colour HEX codes must be preceded by `#`. This is how the other colour dictionaries in the plotting module are currently formatted. Apologies for not conforming to that standard in my earlier PR.