### PR TITLE
Add test compound to COMPOUND_COLORS

### DIFF
--- a/fastf1/plotting.py
+++ b/fastf1/plotting.py
@@ -150,6 +150,7 @@ COMPOUND_COLORS: Dict[str, str] = {
     "INTERMEDIATE": "#43b02a",
     "WET": "#0067ad",
     "UNKNOWN": "#00ffff",
+    "TEST-UNKNOWN": "#434649"
 }
 """Mapping of tyre compound names to compound colors (hex color codes).
 (current season only)"""


### PR DESCRIPTION
The test compound being run in the Barcelona practice sessions is marked `TEST-UNKNOWN` in the API response. Added that to `plotting.COMPOUND_COLORS` or else using the dictionary for these practice sessions will throw a keyerror. Color sourced from F1 timing website.