### PR TITLE
fix code in examples/example_fastf1_signalrclient.py

### DIFF
--- a/examples/example_fastf1_signalrclient.py
+++ b/examples/example_fastf1_signalrclient.py
@@ -5,11 +5,10 @@ Demonstrates the usage of the SignalRClient
 """
 from fastf1.livetiming.client import SignalRClient
 
-import asyncio
 import logging
 
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
 client = SignalRClient(filename="output.txt", debug=True)
-asyncio.run(client.start())
+client.start()


### PR DESCRIPTION
asyncio.run() expects a coroutine. 
In file: `fastf1/livetiming/client.py`, `SignalRClient.start()` already calls asyncio.run(). Therefore with current implementation `SignalRClient.start()` returns `None`, giving the following error:

Current implementation returns:

```2023-07-21 13:59:55,571 - DEBUG: Using selector: KqueueSelector
2023-07-21 13:59:55,571 - INFO: Starting FastF1 live timing client [v3.0.6]
2023-07-21 13:59:55,641 - DEBUG: Starting new HTTPS connection (1): livetiming.formula1.com:443
2023-07-21 13:59:55,927 - DEBUG: https://livetiming.formula1.com:443 "GET /signalr/negotiate?connectionData=%5B%7B%22name%22%3A+%22Streaming%22%7D%5D&clientProtocol=1.5 HTTP/1.1" 200 None
2023-07-21 13:59:56,015 - DEBUG: = connection is CONNECTING
2023-07-21 14:00:55,648 - WARNING: Timeout - received no data for more than 60 seconds!
2023-07-21 14:00:55,649 - WARNING: Exiting...
2023-07-21 14:00:55,651 - DEBUG: Using selector: KqueueSelector
Traceback (most recent call last):
  File "/Users/rafael/Desktop/Privat/testf1/main.py", line 10, in <module>
    asyncio.run(client.start())
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 89, in run
    raise ValueError("a coroutine was expected, got {!r}".format(coro))
ValueError: a coroutine was expected, got None
```

After removing the asyncio part in the example file:
```2023-07-21 14:03:02,813 - DEBUG: Using selector: KqueueSelector
2023-07-21 14:03:02,814 - INFO: Starting FastF1 live timing client [v3.0.6]
2023-07-21 14:03:02,832 - DEBUG: Starting new HTTPS connection (1): livetiming.formula1.com:443
2023-07-21 14:03:03,146 - DEBUG: https://livetiming.formula1.com:443 "GET /signalr/negotiate?connectionData=%5B%7B%22name%22%3A+%22Streaming%22%7D%5D&clientProtocol=1.5 HTTP/1.1" 200 None
2023-07-21 14:03:03,187 - DEBUG: = connection is CONNECTING
2023-07-21 14:04:02,890 - WARNING: Timeout - received no data for more than 60 seconds!
2023-07-21 14:04:02,894 - WARNING: Exiting...
```