### PR TITLE
Fix small typos in docs

### DIFF
--- a/docs/examples/basics.rst
+++ b/docs/examples/basics.rst
@@ -75,7 +75,7 @@ is common for pandas objects:
   Timestamp('2021-06-20 00:00:00')
 
 You can also load an event directly, by using the function
-:func:`fastf1.get_session`. The :class:`~fastf1.events.Event` object in turn
+:func:`fastf1.get_event`. The :class:`~fastf1.events.Event` object in turn
 provides methods for accessing the individual associated sessions.
 
 .. doctest::

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -29,7 +29,7 @@ data for a whole session.
 Usually you will be using :func:`fastf1.get_session` to get a :class:`Session`
 object.
 
-The :class:`Laps` object holds detailed information about multiples laps.
+The :class:`Laps` object holds detailed information about multiple laps.
 
 The :class:`Lap` object holds the same information as :class:`Laps` but only
 for one single lap. When selecting a single lap from a :class:`Laps` object,

--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -231,7 +231,7 @@ def get_session(
 
             >>> get_session(2020, 'Austria', 'Qualifying')
 
-        Get the 3rd session if the 5th Grand Prix in 2021::
+        Get the 3rd session of the 5th Grand Prix in 2021::
 
             >>> get_session(2021, 5, 3)
 


### PR DESCRIPTION
Fixing very small mistakes in documentation saw upon reading the docs.