### PR TITLE
fix: use proper EventFormat label in plot_who_can_still_win_wdc.py

### DIFF
--- a/examples/plot_who_can_still_win_wdc.py
+++ b/examples/plot_who_can_still_win_wdc.py
@@ -32,7 +32,7 @@ def calculate_max_points_for_remaining_season():
 
     events = fastf1.events.get_events_remaining(backend="ergast")
     # Count how many sprints and conventional races are left
-    sprint_events = len(events.loc[events["EventFormat"] == "sprint"])
+    sprint_events = len(events.loc[events["EventFormat"] == "sprint_shoutout"])
     conventional_events = len(events.loc[events["EventFormat"] == "conventional"])
 
     # Calculate points for each


### PR DESCRIPTION
The exemples gallery currently includes an exemple to determine who can still win the wdc.

The `EventFormat` value that is used is `sprint`.  
However, `sprint_shoutout` should be used, as `sprint` will resolve 0 events.
