### PR TITLE
Implement removing first lap pitout time and add tests

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1421,6 +1421,11 @@ class Session:
             mask = pd.isna(result['LapStartTime']) & (~pd.isna(result['PitOutTime']))
             result.loc[mask, 'LapStartTime'] = result.loc[mask, 'PitOutTime']
 
+            # remove first lap pitout time if it is before session_start_time
+            mask = (result["PitOutTime"] < self.session_start_time) & \
+                   (result["NumberOfLaps"] == 1)
+            result.loc[mask, 'PitOutTime'] = pd.NaT
+
             # create total laps counter for each tyre used
             for npit in result['Stint'].unique():
                 sel = result['Stint'] == npit

--- a/fastf1/tests/test_core.py
+++ b/fastf1/tests/test_core.py
@@ -39,6 +39,23 @@ def test_lap_data_loading_position_calculation():
         assert (delta == 0).all()  # assert that the delta is zero for all laps
 
 
+@pytest.mark.f1telapi
+def test_first_lap_pitout_times():
+    sprint_session = fastf1.get_session(2023, 4, "SS")
+    sprint_session.load(telemetry=False, weather=False, messages=False)
+    sprint_laps = sprint_session.laps
+    sprint_mask = (sprint_laps["LapNumber"] == 1) & \
+                  (~sprint_laps["PitOutTime"].isna())
+    assert sprint_laps[sprint_mask]["Driver"].tolist() == ["OCO"]
+
+    race_session = fastf1.get_session(2023, 5, "R")
+    race_session.load(telemetry=False, weather=False, messages=False)
+    race_laps = race_session.laps
+    race_mask = (race_laps["LapNumber"] == 1) & \
+                (~race_laps["PitOutTime"].isna())
+    assert race_laps[race_mask]["Driver"].tolist() == []
+
+
 def test_laps_constructor_metadata_propagation(reference_laps_data):
     session, laps = reference_laps_data
 

--- a/fastf1/tests/test_core.py
+++ b/fastf1/tests/test_core.py
@@ -41,7 +41,7 @@ def test_lap_data_loading_position_calculation():
 
 @pytest.mark.f1telapi
 def test_first_lap_pitout_times():
-    sprint_session = fastf1.get_session(2023, 4, "SS")
+    sprint_session = fastf1.get_session(2023, 4, "Sprint")
     sprint_session.load(telemetry=False, weather=False, messages=False)
     sprint_laps = sprint_session.laps
     sprint_mask = (sprint_laps["LapNumber"] == 1) & \


### PR DESCRIPTION
Reference: #461 

Tested this implementation against all race-like sessions in 2023 and the outputs are as expected.

One case that we didn't explicitly discuss but is handled correctly is drivers pitting at the end of the formation lap. In this case, their pitout times are preserved.