### PR TITLE
Fix inconsistency in pick_fastest, add deprecation warning for future behavior change

### DIFF
--- a/fastf1/_api.py
+++ b/fastf1/_api.py
@@ -1330,6 +1330,7 @@ def race_control_messages(path, response=None, livedata=None):
         - Scope (str): Scope of message "Track", "Sector", "Driver"
         - Sector (int): Affected track sector for sector-scoped messages
         - RacingNumber (str): Affected driver for CarEvent messages
+        - Lap (int): Number of the lap in which the message was displayed
 
     Args:
         path (str): api path base string (usually ``Session.api_path``)
@@ -1361,11 +1362,11 @@ def race_control_messages(path, response=None, livedata=None):
 
     data = {
         'Time': [], 'Category': [], 'Message': [], 'Status': [],
-        'Flag': [], 'Scope': [], 'Sector': [], 'RacingNumber': []
+        'Flag': [], 'Scope': [], 'Sector': [], 'RacingNumber': [], 'Lap': []
     }
     data_keys = ('Category', 'Message', 'Status', 'Flag', 'Scope', 'Sector',
-                 'RacingNumber')
-    converters = (str, str, str, str, str, int, str)
+                 'RacingNumber', 'Lap')
+    converters = (str, str, str, str, str, int, str, int)
 
     for line in response:
         messages = line[1]['Messages']

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -2844,18 +2844,32 @@ class Laps(pd.DataFrame):
         Returns:
             instance of :class:`Lap`
         """
+        # TODO: Deprecate returning empty lap object when there is no lap
+        # that matches definion
         if only_by_time:
             laps = self  # all laps
         else:
             # select only laps marked as personal fastest
-            laps = self.loc[self['IsPersonalBest'] == True]  # noqa: E712 comparison with True
+            laps = self.loc[self['IsPersonalBest'] == True]  # noqa: E712
 
         if not laps.size:
+            warnings.warn(("None will be returned instead of an empty Lap "
+                           "object when there are no laps with "
+                           "IsPersonalBest=True starting from version 3.3"),
+                          DeprecationWarning)
+            return Lap(index=self.columns, dtype=object).__finalize__(self)
+
+        if laps['LapTime'].isna().all():
+            warnings.warn(("None will be returned instead of an empty Lap "
+                           "object when there is no recorded LapTime for "
+                           "any lap with IsPersonalBest=True starting from "
+                           " version 3.3"),
+                          DeprecationWarning)
             return Lap(index=self.columns, dtype=object).__finalize__(self)
 
         lap = laps.loc[laps['LapTime'].idxmin()]
         if isinstance(lap, pd.DataFrame):
-            # More laps, same time
+            # Multiple laps, same time
             lap = lap.iloc[0]  # take first clocked
 
         return lap

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -2854,16 +2854,16 @@ class Laps(pd.DataFrame):
 
         if not laps.size:
             warnings.warn(("None will be returned instead of an empty Lap "
-                           "object when there are no laps with "
-                           "IsPersonalBest=True starting from version 3.3"),
+                           "object when there are no laps that satisfies "
+                           "the definition for fastest lap starting from "
+                           "version 3.3"),
                           DeprecationWarning)
             return Lap(index=self.columns, dtype=object).__finalize__(self)
 
         if laps['LapTime'].isna().all():
             warnings.warn(("None will be returned instead of an empty Lap "
                            "object when there is no recorded LapTime for "
-                           "any lap with IsPersonalBest=True starting from "
-                           " version 3.3"),
+                           "any lap starting from version 3.3"),
                           DeprecationWarning)
             return Lap(index=self.columns, dtype=object).__finalize__(self)
 


### PR DESCRIPTION
Reference: #472 

Handle the uncaught exception. The same empty lap object will be returned regardless of the value of `by_time_only`