### PR TITLE
Expanding Ergast filter parameters 

### DIFF
--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -778,8 +778,7 @@ class Ergast:
                      'fastest_rank': fastest_rank,
                      'status': status}
 
-        return self._build_default_result(endpoint='drivers',
-                                          table='DriverTable',
+        return self._build_default_result(table='DriverTable',
                                           category=API.Drivers,
                                           subcategory=None,
                                           result_type=result_type,
@@ -845,8 +844,7 @@ class Ergast:
                      'fastest_rank': fastest_rank,
                      'status': status}
 
-        return self._build_default_result(endpoint='constructors',
-                                          table='ConstructorTable',
+        return self._build_default_result(table='ConstructorTable',
                                           category=API.Constructors,
                                           subcategory=None,
                                           result_type=result_type,

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -444,13 +444,16 @@ class Ergast:
             selectors.append(f"/{round}")
         if circuit is not None:
             selectors.append(f"/circuits/{circuit}")
-            endpoint = None
+            if endpoint == 'circuits':
+                endpoint = None
         if constructor is not None:
             selectors.append(f"/constructors/{constructor}")
-            endpoint = None
+            if endpoint == 'constructors':
+                endpoint = None
         if driver is not None:
             selectors.append(f"/drivers/{driver}")
-            endpoint = None
+            if endpoint == 'driver':
+                endpoint = None
         if grid_position is not None:
             selectors.append(f"/grid/{grid_position}")
         if results_position is not None:
@@ -459,7 +462,8 @@ class Ergast:
             selectors.append(f"/fastest/{fastest_rank}")
         if status is not None:
             selectors.append(f"/status/{status}")
-            endpoint = None
+            if endpoint == 'status':
+                endpoint = None
 
         # some special cases: the endpoint may also be used as selector
         # therefore, if the specifier is defined, do not add the endpoint

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -442,32 +442,36 @@ class Ergast:
             selectors.append(f"/{season}")
         if round is not None:
             selectors.append(f"/{round}")
-        if circuit is not None:
-            selectors.append(f"/circuits/{circuit}")
-            if endpoint == 'circuits':
-                endpoint = None
-        if constructor is not None:
-            selectors.append(f"/constructors/{constructor}")
-            if endpoint == 'constructors':
-                endpoint = None
-        if driver is not None:
-            selectors.append(f"/drivers/{driver}")
-            if endpoint == 'driver':
-                endpoint = None
         if grid_position is not None:
             selectors.append(f"/grid/{grid_position}")
         if results_position is not None:
             selectors.append(f"/results/{results_position}")
         if fastest_rank is not None:
             selectors.append(f"/fastest/{fastest_rank}")
+
+        # some special cases: the endpoint may also be used as selector
+        # therefore, if the specifier is defined, do not add the endpoint
+        # string additionally
+        if circuit is not None:
+            selectors.append(f"/circuits/{circuit}")
+            if endpoint == 'circuits':
+                endpoint = None
+
+        if constructor is not None:
+            selectors.append(f"/constructors/{constructor}")
+            if endpoint == 'constructors':
+                endpoint = None
+
+        if driver is not None:
+            selectors.append(f"/drivers/{driver}")
+            if endpoint == 'driver':
+                endpoint = None
+
         if status is not None:
             selectors.append(f"/status/{status}")
             if endpoint == 'status':
                 endpoint = None
 
-        # some special cases: the endpoint may also be used as selector
-        # therefore, if the specifier is defined, do not add the endpoint
-        # string additionally
         if standings_position is not None:
             if endpoint == 'driverStandings':
                 selectors.append(f"/driverStandings/{standings_position}")

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -453,51 +453,46 @@ class Ergast:
         # therefore, if the specifier is defined, do not add the endpoint
         # string additionally
         if driver is not None:
-            if endpoint == 'driver':
-                endpoint = f"/drivers/{driver}"
+            if endpoint == 'drivers':
+                endpoint = f"drivers/{driver}"
             else:
                 selectors.append(f"/drivers/{driver}")
 
         if constructor is not None:
             if endpoint == 'constructors':
-                endpoint = f"/constructors/{constructor}"
+                endpoint = f"constructors/{constructor}"
             else:
                 selectors.append(f"/constructors/{constructor}")
 
         if circuit is not None:
             if endpoint == 'circuits':
-                endpoint = f"/circuits/{circuit}"
+                endpoint = f"circuits/{circuit}"
             else:
                 selectors.append(f"/circuits/{circuit}")
 
         if status is not None:
             if endpoint == 'status':
-                endpoint = f"/status/{status}"
+                endpoint = f"status/{status}"
             else:
                 selectors.append(f"/status/{status}")
 
         if standings_position is not None:
             if endpoint == 'driverStandings':
-                endpoint = f"/driverStandings/{standings_position}"
+                endpoint = f"driverStandings/{standings_position}"
             elif endpoint == 'constructorStandings':
-                endpoint = f"/constructorStandings/{standings_position}"
+                endpoint = f"constructorStandings/{standings_position}"
 
         if lap_number is not None:
             if endpoint == 'laps':
-                endpoint = f"/laps/{lap_number}"
+                endpoint = f"laps/{lap_number}"
             else:
                 selectors.append(f"/laps/{lap_number}")
 
         if stop_number is not None:
             if endpoint == 'pitstops':
-                endpoint = f"/pitstops/{stop_number}"
+                endpoint = f"pitstops/{stop_number}"
             else:
                 selectors.append(f"/pitstops/{stop_number}")
-
-        # Special case for race_schedule
-        # If no additional filters besides required (season) exclude endpoint
-        # if endpoint == 'races' and len(selectors) == 1:
-        #     endpoint = None
 
         if endpoint is not None:
             selectors.append(f"/{endpoint}")

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -228,6 +228,7 @@ class ErgastRawResponse(ErgastResponseMixin, list):
         auto_cast: Determines if values are automatically cast to the most
             appropriate data type from their original string representation
     """
+
     def __init__(self, *, query_result, category, auto_cast, **kwargs):
         if auto_cast:
             query_result = self._prepare_response(query_result, category)
@@ -351,6 +352,7 @@ class ErgastMultiResponse(ErgastResponseMixin):
         auto_cast: Flag that enables or disables automatic casting from the
             original string representation to the most suitable data type.
     """
+
     def __init__(self, *args,
                  response_description: dict,
                  response_data: list,
@@ -409,6 +411,7 @@ class Ergast:
             30 if not set. Maximum: 1000. See also "Response Paging" on
             https://ergast.com/mrd/.
     """
+
     def __init__(self,
                  result_type: Literal['raw', 'pandas'] = 'pandas',
                  auto_cast: bool = True,
@@ -434,7 +437,6 @@ class Ergast:
             standings_position: Optional[int] = None
     ) -> str:
         selectors = list()
-        baseJson = True
 
         if season is not None:
             selectors.append(f"/{season}")
@@ -442,31 +444,27 @@ class Ergast:
             selectors.append(f"/{round}")
         if circuit is not None:
             selectors.append(f"/circuits/{circuit}")
-            baseJson = not baseJson
+            endpoint = None
         if constructor is not None:
             selectors.append(f"/constructors/{constructor}")
-            baseJson = not baseJson
+            endpoint = None
         if driver is not None:
-            baseJson = not baseJson
             selectors.append(f"/drivers/{driver}")
+            endpoint = None
         if grid_position is not None:
-            baseJson = not baseJson
             selectors.append(f"/grid/{grid_position}")
         if results_position is not None:
-            baseJson = not baseJson
             selectors.append(f"/results/{results_position}")
         if fastest_rank is not None:
-            baseJson = not baseJson
             selectors.append(f"/fastest/{fastest_rank}")
         if status is not None:
-            baseJson = not baseJson
             selectors.append(f"/status/{status}")
+            endpoint = None
 
         # some special cases: the endpoint may also be used as selector
         # therefore, if the specifier is defined, do not add the endpoint
         # string additionally
         if standings_position is not None:
-            baseJson = not baseJson
             if endpoint == 'driverStandings':
                 selectors.append(f"/driverStandings/{standings_position}")
                 endpoint = None
@@ -475,22 +473,17 @@ class Ergast:
                 endpoint = None
 
         if lap_number is not None:
-            baseJson = not baseJson
             selectors.append(f"/laps/{lap_number}")
             if endpoint == 'laps':
                 endpoint = None
 
         if stop_number is not None:
-            baseJson = not baseJson
             selectors.append(f"/pitstops/{stop_number}")
             if endpoint == 'pitstops':
                 endpoint = None
 
-        # This needs very special cases
-        # Exclusively for season & circuit only, not additional selectors
-        if endpoint is not None and baseJson:
+        if endpoint is not None:
             selectors.append(f"/{endpoint}")
-
 
         return BASE_URL + "".join(selectors) + ".json"
 

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -438,11 +438,8 @@ class Ergast:
     ) -> str:
         selectors = list()
 
-        # ! Need to add endpoint if additional filters otherwise do not
-        # https://ergast.com/mrd/methods/schedule/
         if season is not None:
             selectors.append(f"/{season}")
-
         if round is not None:
             selectors.append(f"/{round}")
         if grid_position is not None:
@@ -499,8 +496,8 @@ class Ergast:
 
         # Special case for race_schedule
         # If no additional filters besides required (season) exclude endpoint
-        if endpoint == 'races' and len(selectors) == 1:
-            endpoint = None
+        # if endpoint == 'races' and len(selectors) == 1:
+        #     endpoint = None
 
         if endpoint is not None:
             selectors.append(f"/{endpoint}")

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -438,8 +438,11 @@ class Ergast:
     ) -> str:
         selectors = list()
 
+        # ! Need to add endpoint if additional filters otherwise do not
+        # https://ergast.com/mrd/methods/schedule/
         if season is not None:
             selectors.append(f"/{season}")
+
         if round is not None:
             selectors.append(f"/{round}")
         if grid_position is not None:
@@ -452,43 +455,52 @@ class Ergast:
         # some special cases: the endpoint may also be used as selector
         # therefore, if the specifier is defined, do not add the endpoint
         # string additionally
-        if circuit is not None:
-            selectors.append(f"/circuits/{circuit}")
-            if endpoint == 'circuits':
-                endpoint = None
+        if driver is not None:
+            if endpoint == 'driver':
+                endpoint = f"/drivers/{driver}"
+            else:
+                selectors.append(f"/drivers/{driver}")
 
         if constructor is not None:
-            selectors.append(f"/constructors/{constructor}")
             if endpoint == 'constructors':
-                endpoint = None
+                endpoint = f"/constructors/{constructor}"
+            else:
+                selectors.append(f"/constructors/{constructor}")
 
-        if driver is not None:
-            selectors.append(f"/drivers/{driver}")
-            if endpoint == 'driver':
-                endpoint = None
+        if circuit is not None:
+            if endpoint == 'circuits':
+                endpoint = f"/circuits/{circuit}"
+            else:
+                selectors.append(f"/circuits/{circuit}")
 
         if status is not None:
-            selectors.append(f"/status/{status}")
             if endpoint == 'status':
-                endpoint = None
+                endpoint = f"/status/{status}"
+            else:
+                selectors.append(f"/status/{status}")
 
         if standings_position is not None:
             if endpoint == 'driverStandings':
-                selectors.append(f"/driverStandings/{standings_position}")
-                endpoint = None
+                endpoint = f"/driverStandings/{standings_position}"
             elif endpoint == 'constructorStandings':
-                selectors.append(f"/constructorStandings/{standings_position}")
-                endpoint = None
+                endpoint = f"/constructorStandings/{standings_position}"
 
         if lap_number is not None:
-            selectors.append(f"/laps/{lap_number}")
             if endpoint == 'laps':
-                endpoint = None
+                endpoint = f"/laps/{lap_number}"
+            else:
+                selectors.append(f"/laps/{lap_number}")
 
         if stop_number is not None:
-            selectors.append(f"/pitstops/{stop_number}")
             if endpoint == 'pitstops':
-                endpoint = None
+                endpoint = f"/pitstops/{stop_number}"
+            else:
+                selectors.append(f"/pitstops/{stop_number}")
+
+        # Special case for race_schedule
+        # If no additional filters besides required (season) exclude endpoint
+        if endpoint == 'races' and len(selectors) == 1:
+            endpoint = None
 
         if endpoint is not None:
             selectors.append(f"/{endpoint}")

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -434,6 +434,7 @@ class Ergast:
             standings_position: Optional[int] = None
     ) -> str:
         selectors = list()
+        baseJson = True
 
         if season is not None:
             selectors.append(f"/{season}")
@@ -441,23 +442,31 @@ class Ergast:
             selectors.append(f"/{round}")
         if circuit is not None:
             selectors.append(f"/circuits/{circuit}")
+            baseJson = not baseJson
         if constructor is not None:
             selectors.append(f"/constructors/{constructor}")
+            baseJson = not baseJson
         if driver is not None:
+            baseJson = not baseJson
             selectors.append(f"/drivers/{driver}")
         if grid_position is not None:
+            baseJson = not baseJson
             selectors.append(f"/grid/{grid_position}")
         if results_position is not None:
+            baseJson = not baseJson
             selectors.append(f"/results/{results_position}")
         if fastest_rank is not None:
+            baseJson = not baseJson
             selectors.append(f"/fastest/{fastest_rank}")
         if status is not None:
+            baseJson = not baseJson
             selectors.append(f"/status/{status}")
 
         # some special cases: the endpoint may also be used as selector
         # therefore, if the specifier is defined, do not add the endpoint
         # string additionally
         if standings_position is not None:
+            baseJson = not baseJson
             if endpoint == 'driverStandings':
                 selectors.append(f"/driverStandings/{standings_position}")
                 endpoint = None
@@ -466,17 +475,22 @@ class Ergast:
                 endpoint = None
 
         if lap_number is not None:
+            baseJson = not baseJson
             selectors.append(f"/laps/{lap_number}")
             if endpoint == 'laps':
                 endpoint = None
 
         if stop_number is not None:
+            baseJson = not baseJson
             selectors.append(f"/pitstops/{stop_number}")
             if endpoint == 'pitstops':
                 endpoint = None
 
-        if endpoint is not None:
+        # This needs very special cases
+        # Exclusively for season & circuit only, not additional selectors
+        if endpoint is not None and baseJson:
             selectors.append(f"/{endpoint}")
+
 
         return BASE_URL + "".join(selectors) + ".json"
 
@@ -778,7 +792,8 @@ class Ergast:
                      'fastest_rank': fastest_rank,
                      'status': status}
 
-        return self._build_default_result(table='DriverTable',
+        return self._build_default_result(endpoint='drivers',
+                                          table='DriverTable',
                                           category=API.Drivers,
                                           subcategory=None,
                                           result_type=result_type,
@@ -844,7 +859,8 @@ class Ergast:
                      'fastest_rank': fastest_rank,
                      'status': status}
 
-        return self._build_default_result(table='ConstructorTable',
+        return self._build_default_result(endpoint="constructors",
+                                          table='ConstructorTable',
                                           category=API.Constructors,
                                           subcategory=None,
                                           result_type=result_type,

--- a/fastf1/tests/test_ergast.py
+++ b/fastf1/tests/test_ergast.py
@@ -313,30 +313,78 @@ def test_merge_dicts_of_lists(data, expected):
 @pytest.mark.parametrize(
     "endpoint, selectors, expected",
     (
-        # "normal" behaviour for most endpoints
+        # "simple" behaviour
         ['seasons', {}, "https://ergast.com/api/f1/seasons.json"],
 
-        ['circuits', {'driver': 'alonso', 'constructor': 'alpine'},
-         "https://ergast.com/api/f1/constructors/alpine/"
-         "drivers/alonso/circuits.json"],
+        ['races', {'season': 2022},
+         "https://ergast.com/api/f1/2022/races.json"],
 
-        # special case where endpoint name matches selector
+        ['results', {'season': 2022, 'round': '10'},
+         "https://ergast.com/api/f1/2022/10/results.json"],
+
+        ['sprint', {'season': 2022, 'round': '4'},
+         "https://ergast.com/api/f1/2022/4/sprint.json"],
+
+        ['qualifying', {'season': 2022, 'round': '10'},
+         "https://ergast.com/api/f1/2022/10/qualifying.json"],
+
+        # special cases where endpoint name matches selector and the endpoint
+        # gets extended with its selection
+        ['drivers', {},
+         "https://ergast.com/api/f1/drivers.json"],
+
+        ['drivers', {'driver': 'alonso'},
+         "https://ergast.com/api/f1/drivers/alonso.json"],
+
+        ['constructors', {},
+         "https://ergast.com/api/f1/constructors.json"],
+
+        ['constructors', {'constructor': 'ferrari'},
+         "https://ergast.com/api/f1/constructors/ferrari.json"],
+
+        ['circuits', {},
+         "https://ergast.com/api/f1/circuits.json"],
+
+        ['circuits', {'circuit': 'monza'},
+         "https://ergast.com/api/f1/circuits/monza.json"],
+
+        ['status', {},
+         "https://ergast.com/api/f1/status.json"],
+
+        ['status', {'status': '1'},
+         "https://ergast.com/api/f1/status/1.json"],
+
+        ['driverStandings', {'season': 2022},
+         "https://ergast.com/api/f1/2022/driverStandings.json"],
+
+        ['driverStandings', {'season': 2022, 'standings_position': '1'},
+         "https://ergast.com/api/f1/2022/driverStandings/1.json"],
+
+        ['constructorStandings', {'season': 2022},
+         "https://ergast.com/api/f1/2022/constructorStandings.json"],
+
+        ['constructorStandings', {'season': 2022, 'standings_position': '1'},
+         "https://ergast.com/api/f1/2022/constructorStandings/1.json"],
+
         ['laps', {'season': 2022, 'round': 10},
          "https://ergast.com/api/f1/2022/10/laps.json"],
 
         ['laps', {'season': 2022, 'round': 10, 'lap_number': 1},
          "https://ergast.com/api/f1/2022/10/laps/1.json"],
 
+        ['pitstops', {'season': 2022, 'round': 10},
+         "https://ergast.com/api/f1/2022/10/pitstops.json"],
+
+        ['pitstops', {'season': 2022, 'round': 10, 'stop_number': '1'},
+         "https://ergast.com/api/f1/2022/10/pitstops/1.json"],
+
         # endpoint/selector combination in other request
         ['pitstops', {'season': 2022, 'round': 10, 'lap_number': 1},
          "https://ergast.com/api/f1/2022/10/laps/1/pitstops.json"],
 
-        # combined selector standings_position
-        ['driverStandings', {'season': 2022, 'standings_position': 1},
-         "https://ergast.com/api/f1/2022/driverStandings/1.json"],
-
-        ['constructorStandings', {'season': 2022, 'standings_position': 3},
-         "https://ergast.com/api/f1/2022/constructorStandings/3.json"]
+        ['circuits', {'driver': 'alonso', 'constructor': 'alpine'},
+         "https://ergast.com/api/f1/drivers/alonso/"
+         "constructors/alpine/circuits.json"],
     )
 )
 def test_ergast_build_url(endpoint: str, selectors: dict, expected: str):


### PR DESCRIPTION
The `_build_url` function leads to an error by adding an additional parameter "endpoint" to the end of the filename for every case. Which leads to `ErgastInvalidRequestError`

The warning can be found [here](https://docs.fastf1.dev/ergast.html#common-surprises):
"Only some combinations of filter parameters are possible and those vary for each API endpoint. FastF1 does not impose restrictions on these combinations as the relationships are fairly complex. Instead, an ErgastInvalidRequestError will be returned in such a case. The exception will contain the error response of the server."

Expected: https://ergast.com/api/f1/2023/drivers/alonso.json
Received: https://ergast.com/api/f1/2023/drivers/alonso/drivers.json

This endpoint needs to be present if no filters are applied or if only season or round filters are used. If any additional filter params are present, we omit the endpoint param, returning a valid URL
