### PR TITLE
Ergast - results final position filter

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -2844,18 +2844,32 @@ class Laps(pd.DataFrame):
         Returns:
             instance of :class:`Lap`
         """
+        # TODO: Deprecate returning empty lap object when there is no lap
+        # that matches definion
         if only_by_time:
             laps = self  # all laps
         else:
             # select only laps marked as personal fastest
-            laps = self.loc[self['IsPersonalBest'] == True]  # noqa: E712 comparison with True
+            laps = self.loc[self['IsPersonalBest'] == True]  # noqa: E712
 
         if not laps.size:
+            warnings.warn(("None will be returned instead of an empty Lap "
+                           "object when there are no laps that satisfies "
+                           "the definition for fastest lap starting from "
+                           "version 3.3"),
+                          DeprecationWarning)
+            return Lap(index=self.columns, dtype=object).__finalize__(self)
+
+        if laps['LapTime'].isna().all():
+            warnings.warn(("None will be returned instead of an empty Lap "
+                           "object when there is no recorded LapTime for "
+                           "any lap starting from version 3.3"),
+                          DeprecationWarning)
             return Lap(index=self.columns, dtype=object).__finalize__(self)
 
         lap = laps.loc[laps['LapTime'].idxmin()]
         if isinstance(lap, pd.DataFrame):
-            # More laps, same time
+            # Multiple laps, same time
             lap = lap.iloc[0]  # take first clocked
 
         return lap

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -778,8 +778,7 @@ class Ergast:
                      'fastest_rank': fastest_rank,
                      'status': status}
 
-        return self._build_default_result(endpoint='drivers',
-                                          table='DriverTable',
+        return self._build_default_result(table='DriverTable',
                                           category=API.Drivers,
                                           subcategory=None,
                                           result_type=result_type,
@@ -845,8 +844,7 @@ class Ergast:
                      'fastest_rank': fastest_rank,
                      'status': status}
 
-        return self._build_default_result(endpoint='constructors',
-                                          table='ConstructorTable',
+        return self._build_default_result(table='ConstructorTable',
                                           category=API.Constructors,
                                           subcategory=None,
                                           result_type=result_type,

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -442,65 +442,47 @@ class Ergast:
             selectors.append(f"/{season}")
         if round is not None:
             selectors.append(f"/{round}")
+        if circuit is not None:
+            selectors.append(f"/circuits/{circuit}")
+        if constructor is not None:
+            selectors.append(f"/constructors/{constructor}")
+        if driver is not None:
+            selectors.append(f"/drivers/{driver}")
         if grid_position is not None:
             selectors.append(f"/grid/{grid_position}")
         if results_position is not None:
             selectors.append(f"/results/{results_position}")
         if fastest_rank is not None:
             selectors.append(f"/fastest/{fastest_rank}")
+        if status is not None:
+            selectors.append(f"/status/{status}")
 
         # some special cases: the endpoint may also be used as selector
         # therefore, if the specifier is defined, do not add the endpoint
         # string additionally
-        if driver is not None:
-            if endpoint == 'driver':
-                endpoint = f"/drivers/{driver}"
-            else:
-                selectors.append(f"/drivers/{driver}")
-
-        if constructor is not None:
-            if endpoint == 'constructors':
-                endpoint = f"/constructors/{constructor}"
-            else:
-                selectors.append(f"/constructors/{constructor}")
-
-        if circuit is not None:
-            if endpoint == 'circuits':
-                endpoint = f"/circuits/{circuit}"
-            else:
-                selectors.append(f"/circuits/{circuit}")
-
-        if status is not None:
-            if endpoint == 'status':
-                endpoint = f"/status/{status}"
-            else:
-                selectors.append(f"/status/{status}")
-
         if standings_position is not None:
             if endpoint == 'driverStandings':
-                endpoint = f"/driverStandings/{standings_position}"
+                selectors.append(f"/driverStandings")
+                endpoint = None
             elif endpoint == 'constructorStandings':
-                endpoint = f"/constructorStandings/{standings_position}"
+                selectors.append(f"/constructorStandings")
+                endpoint = None
 
         if lap_number is not None:
+            selectors.append(f"/laps/{lap_number}")
             if endpoint == 'laps':
-                endpoint = f"/laps/{lap_number}"
-            else:
-                selectors.append(f"/laps/{lap_number}")
+                endpoint = None
 
         if stop_number is not None:
+            selectors.append(f"/pitstops/{stop_number}")
             if endpoint == 'pitstops':
-                endpoint = f"/pitstops/{stop_number}"
-            else:
-                selectors.append(f"/pitstops/{stop_number}")
-
-        # Special case for race_schedule
-        # If no additional filters besides required (season) exclude endpoint
-        # if endpoint == 'races' and len(selectors) == 1:
-        #     endpoint = None
+                endpoint = None
 
         if endpoint is not None:
             selectors.append(f"/{endpoint}")
+
+        if standings_position is not None:
+            selectors.append(f"/{standings_position}")
 
         return BASE_URL + "".join(selectors) + ".json"
 
@@ -869,7 +851,7 @@ class Ergast:
                      'fastest_rank': fastest_rank,
                      'status': status}
 
-        return self._build_default_result(endpoint="constructors",
+        return self._build_default_result(endpoint='constructors',
                                           table='ConstructorTable',
                                           category=API.Constructors,
                                           subcategory=None,
@@ -1026,6 +1008,7 @@ class Ergast:
             grid_position: Optional[int] = None,
             fastest_rank: Optional[int] = None,
             status: Optional[str] = None,
+            standings_position: Optional[int] = None,
             result_type: Optional[Literal['pandas', 'raw']] = None,
             auto_cast: Optional[bool] = None,
             limit: Optional[int] = None,
@@ -1049,6 +1032,7 @@ class Ergast:
             grid_position: select a grid position by its number (default: all)
             fastest_rank: select fastest by rank number (default: all)
             status: select by finishing status (default: all)
+            standings_position: select a result by final position (default: all)
             result_type: Overwrites the default result type
             auto_cast: Overwrites the default value for ``auto_cast``
             limit: Overwrites the default value for ``limit``
@@ -1068,7 +1052,8 @@ class Ergast:
                      'driver': driver,
                      'grid_position': grid_position,
                      'fastest_rank': fastest_rank,
-                     'status': status}
+                     'status': status,
+                     'standings_position': standings_position}
 
         return self._build_default_result(endpoint='results',
                                           table='RaceTable',
@@ -1091,6 +1076,7 @@ class Ergast:
             results_position: Optional[int] = None,
             fastest_rank: Optional[int] = None,
             status: Optional[str] = None,
+            standings_position: Optional[int] = None,
             result_type: Optional[Literal['pandas', 'raw']] = None,
             auto_cast: Optional[bool] = None,
             limit: Optional[int] = None,
@@ -1116,6 +1102,7 @@ class Ergast:
                 (default: all)
             fastest_rank: select fastest by rank number (default: all)
             status: select by finishing status (default: all)
+            standings_position: select a result by final position (default: all)
             result_type: Overwrites the default result type
             auto_cast: Overwrites the default value for ``auto_cast``
             limit: Overwrites the default value for ``limit``
@@ -1136,7 +1123,8 @@ class Ergast:
                      'grid_position': grid_position,
                      'results_position': results_position,
                      'fastest_rank': fastest_rank,
-                     'status': status}
+                     'status': status,
+                     'standings_position': standings_position}
 
         return self._build_default_result(endpoint='qualifying',
                                           table='RaceTable',
@@ -1157,6 +1145,7 @@ class Ergast:
             driver: Optional[str] = None,
             grid_position: Optional[int] = None,
             status: Optional[str] = None,
+            standings_position: Optional[int] = None,
             result_type: Optional[Literal['pandas', 'raw']] = None,
             auto_cast: Optional[bool] = None,
             limit: Optional[int] = None,
@@ -1179,6 +1168,7 @@ class Ergast:
             driver: select a driver by its driver id (default: all)
             grid_position: select a grid position by its number (default: all)
             status: select by finishing status (default: all)
+            standings_position: select a result by final position (default: all)
             result_type: Overwrites the default result type
             auto_cast: Overwrites the default value for ``auto_cast``
             limit: Overwrites the default value for ``limit``
@@ -1197,7 +1187,8 @@ class Ergast:
                      'constructor': constructor,
                      'driver': driver,
                      'grid_position': grid_position,
-                     'status': status}
+                     'status': status,
+                     'standings_position': standings_position}
 
         return self._build_default_result(endpoint='sprint',
                                           table='RaceTable',

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -444,8 +444,6 @@ class Ergast:
             selectors.append(f"/{round}")
         if grid_position is not None:
             selectors.append(f"/grid/{grid_position}")
-        if results_position is not None:
-            selectors.append(f"/results/{results_position}")
         if fastest_rank is not None:
             selectors.append(f"/fastest/{fastest_rank}")
 
@@ -481,6 +479,12 @@ class Ergast:
                 endpoint = f"driverStandings/{standings_position}"
             elif endpoint == 'constructorStandings':
                 endpoint = f"constructorStandings/{standings_position}"
+
+        if results_position is not None:
+            if endpoint in ('results', 'qualifying', 'sprint'):
+                endpoint = f"{endpoint}/{results_position}"
+            else:
+                selectors.append(f"/results/{results_position}")
 
         if lap_number is not None:
             if endpoint == 'laps':
@@ -1019,6 +1023,7 @@ class Ergast:
             constructor: Optional[str] = None,
             driver: Optional[str] = None,
             grid_position: Optional[int] = None,
+            results_position: Optional[int] = None,
             fastest_rank: Optional[int] = None,
             status: Optional[str] = None,
             result_type: Optional[Literal['pandas', 'raw']] = None,
@@ -1042,6 +1047,8 @@ class Ergast:
                 (default: all)
             driver: select a driver by its driver id (default: all)
             grid_position: select a grid position by its number (default: all)
+            results_position: select a finishing result by its position
+                (default: all)
             fastest_rank: select fastest by rank number (default: all)
             status: select by finishing status (default: all)
             result_type: Overwrites the default result type
@@ -1062,6 +1069,7 @@ class Ergast:
                      'constructor': constructor,
                      'driver': driver,
                      'grid_position': grid_position,
+                     'results_position': results_position,
                      'fastest_rank': fastest_rank,
                      'status': status}
 
@@ -1151,6 +1159,7 @@ class Ergast:
             constructor: Optional[str] = None,
             driver: Optional[str] = None,
             grid_position: Optional[int] = None,
+            results_position: Optional[int] = None,
             status: Optional[str] = None,
             result_type: Optional[Literal['pandas', 'raw']] = None,
             auto_cast: Optional[bool] = None,
@@ -1173,6 +1182,8 @@ class Ergast:
                 (default: all)
             driver: select a driver by its driver id (default: all)
             grid_position: select a grid position by its number (default: all)
+            results_position: select a finishing result by its position
+                (default: all)
             status: select by finishing status (default: all)
             result_type: Overwrites the default result type
             auto_cast: Overwrites the default value for ``auto_cast``
@@ -1192,6 +1203,7 @@ class Ergast:
                      'constructor': constructor,
                      'driver': driver,
                      'grid_position': grid_position,
+                     'results_position': results_position,
                      'status': status}
 
         return self._build_default_result(endpoint='sprint',

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -444,13 +444,16 @@ class Ergast:
             selectors.append(f"/{round}")
         if circuit is not None:
             selectors.append(f"/circuits/{circuit}")
-            endpoint = None
+            if endpoint == 'circuits':
+                endpoint = None
         if constructor is not None:
             selectors.append(f"/constructors/{constructor}")
-            endpoint = None
+            if endpoint == 'constructors':
+                endpoint = None
         if driver is not None:
             selectors.append(f"/drivers/{driver}")
-            endpoint = None
+            if endpoint == 'driver':
+                endpoint = None
         if grid_position is not None:
             selectors.append(f"/grid/{grid_position}")
         if results_position is not None:
@@ -459,7 +462,8 @@ class Ergast:
             selectors.append(f"/fastest/{fastest_rank}")
         if status is not None:
             selectors.append(f"/status/{status}")
-            endpoint = None
+            if endpoint == 'status':
+                endpoint = None
 
         # some special cases: the endpoint may also be used as selector
         # therefore, if the specifier is defined, do not add the endpoint

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -442,32 +442,36 @@ class Ergast:
             selectors.append(f"/{season}")
         if round is not None:
             selectors.append(f"/{round}")
-        if circuit is not None:
-            selectors.append(f"/circuits/{circuit}")
-            if endpoint == 'circuits':
-                endpoint = None
-        if constructor is not None:
-            selectors.append(f"/constructors/{constructor}")
-            if endpoint == 'constructors':
-                endpoint = None
-        if driver is not None:
-            selectors.append(f"/drivers/{driver}")
-            if endpoint == 'driver':
-                endpoint = None
         if grid_position is not None:
             selectors.append(f"/grid/{grid_position}")
         if results_position is not None:
             selectors.append(f"/results/{results_position}")
         if fastest_rank is not None:
             selectors.append(f"/fastest/{fastest_rank}")
+
+        # some special cases: the endpoint may also be used as selector
+        # therefore, if the specifier is defined, do not add the endpoint
+        # string additionally
+        if circuit is not None:
+            selectors.append(f"/circuits/{circuit}")
+            if endpoint == 'circuits':
+                endpoint = None
+
+        if constructor is not None:
+            selectors.append(f"/constructors/{constructor}")
+            if endpoint == 'constructors':
+                endpoint = None
+
+        if driver is not None:
+            selectors.append(f"/drivers/{driver}")
+            if endpoint == 'driver':
+                endpoint = None
+
         if status is not None:
             selectors.append(f"/status/{status}")
             if endpoint == 'status':
                 endpoint = None
 
-        # some special cases: the endpoint may also be used as selector
-        # therefore, if the specifier is defined, do not add the endpoint
-        # string additionally
         if standings_position is not None:
             if endpoint == 'driverStandings':
                 selectors.append(f"/driverStandings/{standings_position}")

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -228,6 +228,7 @@ class ErgastRawResponse(ErgastResponseMixin, list):
         auto_cast: Determines if values are automatically cast to the most
             appropriate data type from their original string representation
     """
+
     def __init__(self, *, query_result, category, auto_cast, **kwargs):
         if auto_cast:
             query_result = self._prepare_response(query_result, category)
@@ -351,6 +352,7 @@ class ErgastMultiResponse(ErgastResponseMixin):
         auto_cast: Flag that enables or disables automatic casting from the
             original string representation to the most suitable data type.
     """
+
     def __init__(self, *args,
                  response_description: dict,
                  response_data: list,
@@ -409,6 +411,7 @@ class Ergast:
             30 if not set. Maximum: 1000. See also "Response Paging" on
             https://ergast.com/mrd/.
     """
+
     def __init__(self,
                  result_type: Literal['raw', 'pandas'] = 'pandas',
                  auto_cast: bool = True,
@@ -434,7 +437,6 @@ class Ergast:
             standings_position: Optional[int] = None
     ) -> str:
         selectors = list()
-        baseJson = True
 
         if season is not None:
             selectors.append(f"/{season}")
@@ -442,31 +444,27 @@ class Ergast:
             selectors.append(f"/{round}")
         if circuit is not None:
             selectors.append(f"/circuits/{circuit}")
-            baseJson = not baseJson
+            endpoint = None
         if constructor is not None:
             selectors.append(f"/constructors/{constructor}")
-            baseJson = not baseJson
+            endpoint = None
         if driver is not None:
-            baseJson = not baseJson
             selectors.append(f"/drivers/{driver}")
+            endpoint = None
         if grid_position is not None:
-            baseJson = not baseJson
             selectors.append(f"/grid/{grid_position}")
         if results_position is not None:
-            baseJson = not baseJson
             selectors.append(f"/results/{results_position}")
         if fastest_rank is not None:
-            baseJson = not baseJson
             selectors.append(f"/fastest/{fastest_rank}")
         if status is not None:
-            baseJson = not baseJson
             selectors.append(f"/status/{status}")
+            endpoint = None
 
         # some special cases: the endpoint may also be used as selector
         # therefore, if the specifier is defined, do not add the endpoint
         # string additionally
         if standings_position is not None:
-            baseJson = not baseJson
             if endpoint == 'driverStandings':
                 selectors.append(f"/driverStandings/{standings_position}")
                 endpoint = None
@@ -475,22 +473,17 @@ class Ergast:
                 endpoint = None
 
         if lap_number is not None:
-            baseJson = not baseJson
             selectors.append(f"/laps/{lap_number}")
             if endpoint == 'laps':
                 endpoint = None
 
         if stop_number is not None:
-            baseJson = not baseJson
             selectors.append(f"/pitstops/{stop_number}")
             if endpoint == 'pitstops':
                 endpoint = None
 
-        # This needs very special cases
-        # Exclusively for season & circuit only, not additional selectors
-        if endpoint is not None and baseJson:
+        if endpoint is not None:
             selectors.append(f"/{endpoint}")
-
 
         return BASE_URL + "".join(selectors) + ".json"
 

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -438,11 +438,8 @@ class Ergast:
     ) -> str:
         selectors = list()
 
-        # ! Need to add endpoint if additional filters otherwise do not
-        # https://ergast.com/mrd/methods/schedule/
         if season is not None:
             selectors.append(f"/{season}")
-
         if round is not None:
             selectors.append(f"/{round}")
         if grid_position is not None:
@@ -499,8 +496,8 @@ class Ergast:
 
         # Special case for race_schedule
         # If no additional filters besides required (season) exclude endpoint
-        if endpoint == 'races' and len(selectors) == 1:
-            endpoint = None
+        # if endpoint == 'races' and len(selectors) == 1:
+        #     endpoint = None
 
         if endpoint is not None:
             selectors.append(f"/{endpoint}")

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -438,8 +438,11 @@ class Ergast:
     ) -> str:
         selectors = list()
 
+        # ! Need to add endpoint if additional filters otherwise do not
+        # https://ergast.com/mrd/methods/schedule/
         if season is not None:
             selectors.append(f"/{season}")
+
         if round is not None:
             selectors.append(f"/{round}")
         if grid_position is not None:
@@ -452,43 +455,52 @@ class Ergast:
         # some special cases: the endpoint may also be used as selector
         # therefore, if the specifier is defined, do not add the endpoint
         # string additionally
-        if circuit is not None:
-            selectors.append(f"/circuits/{circuit}")
-            if endpoint == 'circuits':
-                endpoint = None
+        if driver is not None:
+            if endpoint == 'driver':
+                endpoint = f"/drivers/{driver}"
+            else:
+                selectors.append(f"/drivers/{driver}")
 
         if constructor is not None:
-            selectors.append(f"/constructors/{constructor}")
             if endpoint == 'constructors':
-                endpoint = None
+                endpoint = f"/constructors/{constructor}"
+            else:
+                selectors.append(f"/constructors/{constructor}")
 
-        if driver is not None:
-            selectors.append(f"/drivers/{driver}")
-            if endpoint == 'driver':
-                endpoint = None
+        if circuit is not None:
+            if endpoint == 'circuits':
+                endpoint = f"/circuits/{circuit}"
+            else:
+                selectors.append(f"/circuits/{circuit}")
 
         if status is not None:
-            selectors.append(f"/status/{status}")
             if endpoint == 'status':
-                endpoint = None
+                endpoint = f"/status/{status}"
+            else:
+                selectors.append(f"/status/{status}")
 
         if standings_position is not None:
             if endpoint == 'driverStandings':
-                selectors.append(f"/driverStandings/{standings_position}")
-                endpoint = None
+                endpoint = f"/driverStandings/{standings_position}"
             elif endpoint == 'constructorStandings':
-                selectors.append(f"/constructorStandings/{standings_position}")
-                endpoint = None
+                endpoint = f"/constructorStandings/{standings_position}"
 
         if lap_number is not None:
-            selectors.append(f"/laps/{lap_number}")
             if endpoint == 'laps':
-                endpoint = None
+                endpoint = f"/laps/{lap_number}"
+            else:
+                selectors.append(f"/laps/{lap_number}")
 
         if stop_number is not None:
-            selectors.append(f"/pitstops/{stop_number}")
             if endpoint == 'pitstops':
-                endpoint = None
+                endpoint = f"/pitstops/{stop_number}"
+            else:
+                selectors.append(f"/pitstops/{stop_number}")
+
+        # Special case for race_schedule
+        # If no additional filters besides required (season) exclude endpoint
+        if endpoint == 'races' and len(selectors) == 1:
+            endpoint = None
 
         if endpoint is not None:
             selectors.append(f"/{endpoint}")

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -434,6 +434,7 @@ class Ergast:
             standings_position: Optional[int] = None
     ) -> str:
         selectors = list()
+        baseJson = True
 
         if season is not None:
             selectors.append(f"/{season}")
@@ -441,23 +442,31 @@ class Ergast:
             selectors.append(f"/{round}")
         if circuit is not None:
             selectors.append(f"/circuits/{circuit}")
+            baseJson = not baseJson
         if constructor is not None:
             selectors.append(f"/constructors/{constructor}")
+            baseJson = not baseJson
         if driver is not None:
+            baseJson = not baseJson
             selectors.append(f"/drivers/{driver}")
         if grid_position is not None:
+            baseJson = not baseJson
             selectors.append(f"/grid/{grid_position}")
         if results_position is not None:
+            baseJson = not baseJson
             selectors.append(f"/results/{results_position}")
         if fastest_rank is not None:
+            baseJson = not baseJson
             selectors.append(f"/fastest/{fastest_rank}")
         if status is not None:
+            baseJson = not baseJson
             selectors.append(f"/status/{status}")
 
         # some special cases: the endpoint may also be used as selector
         # therefore, if the specifier is defined, do not add the endpoint
         # string additionally
         if standings_position is not None:
+            baseJson = not baseJson
             if endpoint == 'driverStandings':
                 selectors.append(f"/driverStandings/{standings_position}")
                 endpoint = None
@@ -466,17 +475,22 @@ class Ergast:
                 endpoint = None
 
         if lap_number is not None:
+            baseJson = not baseJson
             selectors.append(f"/laps/{lap_number}")
             if endpoint == 'laps':
                 endpoint = None
 
         if stop_number is not None:
+            baseJson = not baseJson
             selectors.append(f"/pitstops/{stop_number}")
             if endpoint == 'pitstops':
                 endpoint = None
 
-        if endpoint is not None:
+        # This needs very special cases
+        # Exclusively for season & circuit only, not additional selectors
+        if endpoint is not None and baseJson:
             selectors.append(f"/{endpoint}")
+
 
         return BASE_URL + "".join(selectors) + ".json"
 
@@ -778,7 +792,8 @@ class Ergast:
                      'fastest_rank': fastest_rank,
                      'status': status}
 
-        return self._build_default_result(table='DriverTable',
+        return self._build_default_result(endpoint='drivers',
+                                          table='DriverTable',
                                           category=API.Drivers,
                                           subcategory=None,
                                           result_type=result_type,
@@ -844,7 +859,8 @@ class Ergast:
                      'fastest_rank': fastest_rank,
                      'status': status}
 
-        return self._build_default_result(table='ConstructorTable',
+        return self._build_default_result(endpoint="constructors",
+                                          table='ConstructorTable',
                                           category=API.Constructors,
                                           subcategory=None,
                                           result_type=result_type,


### PR DESCRIPTION
**Expanding `standings_position` from Driver & Constructor Standings to Race, Qualifying, & Sprint results.**

Changes for `get_race_results()`, `get_qualifying_results()`, `get_sprint_results()`

- Adding the parameter `standings_position` the same as it is done for `get_driver_standings()` and `get_constructor_standings()`. This name does not accurately describe the value. However the var is pre-existing and exhibits the same behavior as needed.

Changes for building the url:

- Use the `standings_position` as the final selector when building the url.

Ergast documentation to support
```
Driver Standings:
All winners of the driver or constructor championships can be obtained using:
https://ergast.com/api/f1/driverStandings/1
https://ergast.com/api/f1/constructorStandings/1

Race:
So to list all drivers and constructors winning races in a season:
https://ergast.com/api/f1/2008/results/1

Qualifying:
If you are only interested in qualifying results with a specific finishing position you can add a qualifier:
https://ergast.com/api/f1/2008/qualifying/1

Sprint
If you are only interested in results for a specific finishing position you can add a qualifier:
https://ergast.com/api/f1/2021/sprint/1
```

**Note this is a fresh version of interface.py omitting changes from other PRs**