### PR TITLE
Remove unused InvalidSessionError

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -59,6 +59,3 @@
   **********
 
     .. autoclass:: fastf1.core.NoLapDataError
-
-
-    .. autoclass:: fastf1.core.InvalidSessionError

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -3696,13 +3696,3 @@ class NoLapDataError(Exception):
         super(NoLapDataError, self).__init__("Failed to load session because "
                                              "the API did not provide any "
                                              "usable data.")
-
-
-class InvalidSessionError(Exception):
-    """Raised if no session for the specified event name, type and year
-    can be found."""
-
-    def __init__(self, *args):
-        super(InvalidSessionError, self).__init__(
-            "No matching session can be found."
-        )


### PR DESCRIPTION
Doing a bit of research on FastF1 exceptions for my own project and saw that `InvalidSessionError` is declared but not used anywhere.

Seems like it was added as a bandaid solution in this [commit](https://github.com/theOehrly/Fast-F1/commit/1496d5bda636f2e794e7fc9632bb5089c108b95f)