### PR TITLE
ENH: Declare Sprint Qualifying as a quali-like session

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -79,8 +79,8 @@ from fastf1.utils import to_timedelta
 
 _logger = get_logger(__name__)
 
-_RACE_LIKE_SESSIONS = ('Race', 'Sprint', 'Sprint Qualifying')
-_QUALI_LIKE_SESSIONS = ('Qualifying', 'Sprint Shootout')
+_RACE_LIKE_SESSIONS = ('Race', 'Sprint')
+_QUALI_LIKE_SESSIONS = ('Qualifying', 'Sprint Shootout', 'Sprint Qualifying')
 
 
 class Telemetry(pd.DataFrame):


### PR DESCRIPTION
Sprint Qualifying for 2024 is now a Quali-Like session (not Race-Like like before).
Also fixes `Laps.split_qualifying_sessions()` for the Sprint Qualifying