### PR TITLE
Silently create test_cache if it does not exist

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -134,6 +134,13 @@ def reference_laps_data():
 def fastf1_setup():
     import fastf1
     from fastf1.logger import LoggingManager
-    fastf1.Cache.enable_cache('test_cache')  # use specific cache directory
+
+    try:
+        fastf1.Cache.enable_cache('test_cache')  # use specific cache directory
+    except NotADirectoryError:
+        # create the test cache and re-enable
+        os.mkdir('test_cache')
+        fastf1.Cache.enable_cache('test_cache')
+
     fastf1.Cache.ci_mode(True)  # only request uncached data
     LoggingManager.debug = True  # raise all exceptions


### PR DESCRIPTION
If you are running tests locally and the `test_cache` directory hasn't been created before, `enable_cache` throws the following error:

`NotADirectoryError: Cache directory does not exist! Please check for typos or create it first.`

This is counter-intuitive as most contributors would have a cache enabled somewhere already.

Opening the PR to propose that this be handled silently (or with log output). The specific cache location might need to be changed to be consistent with the general fastf1 cache