### PR TITLE
Improved fuzzy matching with warning

### DIFF
--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -361,7 +361,8 @@ def get_event(
         *,
         backend: Optional[Literal['fastf1', 'f1timing', 'ergast']] = None,
         force_ergast: bool = False,
-        strict_search: bool = False
+        strict_search: bool = False,
+        exact_match: bool = False
 ) -> "Event":
     """Create an :class:`~fastf1.events.Event` object for a specific
     season and gp.
@@ -400,9 +401,12 @@ def get_event(
         force_ergast: [Deprecated, use ``backend='ergast'``] Always use data
             from the ergast database to create the event schedule
 
-        strict_search: Match precisely the query, or default to
+        strict_search: This argument is deprecated and planned for removal,
+            use the equivalent ``exact_match`` instead
+
+        exact_match: Match precisely the query, or default to
             fuzzy search. If no event is found with
-            ``strict_search=True``, the function will return None
+            ``exact_match=True``, the function will return None
 
     .. versionadded:: 2.2
     """
@@ -411,7 +415,8 @@ def get_event(
                                   backend=backend)
 
     if isinstance(gp, str):
-        event = schedule.get_event_by_name(gp, strict_search=strict_search)
+        event = schedule.get_event_by_name(
+            gp, strict_search=strict_search, exact_match=exact_match)
     else:
         event = schedule.get_event_by_round(gp)
 
@@ -958,7 +963,8 @@ class EventSchedule(BaseDataFrame):
             self,
             name: str,
             *,
-            strict_search: bool = False
+            strict_search: bool = False,
+            exact_match: bool = False
     ) -> "Event":
         """Get an :class:`Event` by its name.
 
@@ -981,16 +987,21 @@ class EventSchedule(BaseDataFrame):
                 ``.get_event_by_name("british")`` and
                 ``.get_event_by_name("silverstone")`` will both return the
                 event for the British Grand Prix.
-            strict_search: Search only for exact query matches
+            strict_search: This argument is deprecated and planned for removal.
+                Use the equivalent ``exact_match`` instead
+            exact_match: Search only for exact query matches
                 instead of using fuzzy search. For example,
                 ``.get_event_by_name("British Grand Prix",
-                strict_search=True)``
+                exact_match=True)``
                 will return the event for the British Grand Prix, whereas
-                ``.get_event_by_name("British", strict_search=True)``
+                ``.get_event_by_name("British", exact_match=True)``
                 will return ``None``
         """
-
         if strict_search:
+            warnings.warn(("strict_search is deprecated and planned for "
+                           "removal, use the equivalent exact_match instead"),
+                          FutureWarning)
+        if strict_search or exact_match:
             return self._strict_event_search(name)
         else:
             return self._fuzzy_event_search(name)

--- a/fastf1/tests/test_events.py
+++ b/fastf1/tests/test_events.py
@@ -132,6 +132,55 @@ def test_event_schedule_get_by_name():
     assert schedule.get_event_by_name('test-test').EventName == 'test_test'
 
 
+def test_event_fuzzy_search():
+    # highest overlap case
+    schedule = fastf1.get_event_schedule(1979)
+    assert schedule.get_event_by_name(
+        "United States").EventName == "United States Grand Prix"
+    assert schedule.get_event_by_name(
+        "United States Grand Prix").EventName == "United States Grand Prix"
+    assert schedule.get_event_by_name(
+        "United States West").EventName == "United States Grand Prix West"
+    assert schedule.get_event_by_name(
+        "United States West Grand Prix").EventName == "United States Grand Prix West"
+    assert schedule.get_event_by_name(
+        "US West").EventName == "United States Grand Prix West"
+
+    # Multiple races are held at the same venue during the 2020 season
+    schedule = fastf1.get_event_schedule(2020)
+    # Prefer Austrian GP over Styrian GP
+    assert schedule.get_event_by_name(
+        "Austria").EventName == "Austrian Grand Prix"
+    # Prefer Bahrain GP over Sakhir GP
+    assert schedule.get_event_by_name(
+        "Bahrain").EventName == "Bahrain Grand Prix"
+
+    # tests for common inputs
+    schedule = fastf1.get_event_schedule(2024)
+    assert schedule.get_event_by_name(
+        "Saudi").EventName == "Saudi Arabian Grand Prix"
+    assert schedule.get_event_by_name(
+        "Saudi GP").EventName == "Saudi Arabian Grand Prix"
+    assert schedule.get_event_by_name(
+        "Saudi Grand Prix").EventName == "Saudi Arabian Grand Prix"
+    assert schedule.get_event_by_name(
+        "Jeddah").EventName == "Saudi Arabian Grand Prix"
+    assert schedule.get_event_by_name(
+        "Saudi Arabia").EventName == "Saudi Arabian Grand Prix"
+
+    # tests agaisnt colloquialisms
+    assert schedule.get_event_by_name(
+        "Imola").EventName == "Emilia Romagna Grand Prix"
+    assert schedule.get_event_by_name(
+        "USGP").EventName == "United States Grand Prix"
+    assert schedule.get_event_by_name(
+        "US GP").EventName == "United States Grand Prix"
+    assert schedule.get_event_by_name(
+        "Mexican GP").EventName == "Mexico City Grand Prix"
+    assert schedule.get_event_by_name(
+        "Brazilian GP").EventName == "São Paulo Grand Prix"
+
+
 @pytest.mark.parametrize(
     'backend, no_testing_support',
     [('fastf1', False), ('f1timing', False), ('ergast', True)],


### PR DESCRIPTION
Added test cases to the fuzzy version of `get_event_by_name` and reimplemented some logic to avoid false positive warnings.

I recommend considering using [RapidFuzz](https://github.com/rapidfuzz/RapidFuzz?tab=readme-ov-file) over [thefuzz](https://github.com/seatgeek/thefuzz?tab=readme-ov-file) since it seems to be more widely adopted and actively maintained. The performance difference is not important for our use case. The API is identical so this only requires changing the requirements. I will put it in a separate PR if you like the idea.