### PR TITLE
CI: use separate cache for minversion tests

### DIFF
--- a/.github/workflows/selective_cache_persist.yml
+++ b/.github/workflows/selective_cache_persist.yml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12']
-    name: Tests on ${{ matrix.python-version }}
+        python-version: [ '3.8-minver', '3.8', '3.9', '3.10', '3.11', '3.12']
+        #
+    name: Persist cache for ${{ matrix.python-version }}
     steps:
       - name: Create cache directory
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
         include:
           - name-suffix: "(Minimum Versions)"
             python-version: "3.8"
+            cache-suffix: "-minver"
             extra-requirements: "-c requirements/minver.txt"
           - python-version: "3.8"
           - python-version: "3.9"
@@ -59,9 +60,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./test_cache
-          key: fastf1-${{ matrix.python-version }}-${{ hashFiles('*.*') }}
+          key: fastf1-${{ matrix.python-version }}${{ matrix.cache-suffix }}-${{ hashFiles('*.*') }}
           restore-keys: |
-            fastf1-${{ matrix.python-version }}
+            fastf1-${{ matrix.python-version }}${{ matrix.cache-suffix }}
 
       - name: Run tests
         run: |


### PR DESCRIPTION
Fixes test failures caused by requests-cache getting incompatible data from the cache.

(mismatch between offset-naive and offset-aware datetimes)