### PR TITLE
Fix-569: set Laptime to NaT for drivers crashed in lap 1. Assign NaN position.

### DIFF
--- a/docs/changelog/v3.3.x.rst
+++ b/docs/changelog/v3.3.x.rst
@@ -1,3 +1,25 @@
+What's new in v3.3.6
+--------------------
+
+(released 16/05/2024)
+
+
+Bug Fixes
+^^^^^^^^^
+
+- Laps where a driver crashes and retires on track now contain a correct
+  track status (fixes #575)
+
+- Fixed previously incorrect circuit info for Mugello 2020 (fixes #563)
+
+
+Others
+^^^^^^
+
+- Improved a warning message that informs about missing data when calculating
+  qualification results
+
+
 What's new in v3.3.5
 --------------------
 

--- a/fastf1/__init__.py
+++ b/fastf1/__init__.py
@@ -103,8 +103,6 @@ else:
     __version_short__ = __version__
 
 
-from typing import Dict
-
 from fastf1.events import get_session  # noqa: F401
 from fastf1.events import (  # noqa: F401
     get_event,
@@ -118,51 +116,3 @@ from fastf1.req import (  # noqa: F401
     Cache,
     RateLimitExceededError
 )
-
-
-_DRIVER_TEAM_MAPPING: Dict[str, Dict[str, str]] = {
-    # only necessary when loading live timing data that does not include
-    # the driver and team listing and no data is available on ergast yet
-    '23': {'Abbreviation': 'ALB', 'FirstName': 'Alexander',
-           'LastName': 'Albon', 'TeamName': 'Williams'},
-    '14': {'Abbreviation': 'ALO', 'FirstName': 'Fernando',
-           'LastName': 'Alonso', 'TeamName': 'Alpine F1 Team'},
-    '77': {'Abbreviation': 'BOT', 'FirstName': 'Valtteri',
-           'LastName': 'Bottas', 'TeamName': 'Alfa Romeo'},
-    '10': {'Abbreviation': 'GAS', 'FirstName': 'Pierre',
-           'LastName': 'Gasly', 'TeamName': 'AlphaTauri'},
-    '44': {'Abbreviation': 'HAM', 'FirstName': 'Lewis',
-           'LastName': 'Hamilton', 'TeamName': 'Mercedes'},
-    '27': {'Abbreviation': 'HUL', 'FirstName': 'Nico',
-           'LastName': 'Hülkenberg', 'TeamName': 'Aston Martin'},
-    '6': {'Abbreviation': 'LAT', 'FirstName': 'Nicholas',
-          'LastName': 'Latifi', 'TeamName': 'Williams'},
-    '16': {'Abbreviation': 'LEC', 'FirstName': 'Charles',
-           'LastName': 'Leclerc', 'TeamName': 'Ferrari'},
-    '20': {'Abbreviation': 'MAG', 'FirstName': 'Kevin',
-           'LastName': 'Magnussen', 'TeamName': 'Haas F1 Team'},
-    '4': {'Abbreviation': 'NOR', 'FirstName': 'Lando',
-          'LastName': 'Norris', 'TeamName': 'McLaren'},
-    '31': {'Abbreviation': 'OCO', 'FirstName': 'Esteban',
-           'LastName': 'Ocon', 'TeamName': 'Alpine F1 Team'},
-    '11': {'Abbreviation': 'PER', 'FirstName': 'Sergio',
-           'LastName': 'Pérez', 'TeamName': 'Red Bull'},
-    '3': {'Abbreviation': 'RIC', 'FirstName': 'Daniel',
-          'LastName': 'Ricciardo', 'TeamName': 'McLaren'},
-    '63': {'Abbreviation': 'RUS', 'FirstName': 'George',
-           'LastName': 'Russell', 'TeamName': 'Mercedes'},
-    '55': {'Abbreviation': 'SAI', 'FirstName': 'Carlos',
-           'LastName': 'Sainz', 'TeamName': 'Ferrari'},
-    '47': {'Abbreviation': 'MSC', 'FirstName': 'Mick',
-           'LastName': 'Schumacher', 'TeamName': 'Haas F1 Team'},
-    '18': {'Abbreviation': 'STR', 'FirstName': 'Lance',
-           'LastName': 'Stroll', 'TeamName': 'Aston Martin'},
-    '22': {'Abbreviation': 'TSU', 'FirstName': 'Yuki',
-           'LastName': 'Tsunoda', 'TeamName': 'AlphaTauri'},
-    '1': {'Abbreviation': 'VER', 'FirstName': 'Max',
-          'LastName': 'Verstappen', 'TeamName': 'Red Bull'},
-    '5': {'Abbreviation': 'VET', 'FirstName': 'Sebastian',
-          'LastName': 'Vettel', 'TeamName': 'Aston Martin'},
-    '24': {'Abbreviation': 'ZHO', 'FirstName': 'Guanyu',
-           'LastName': 'Zhou', 'TeamName': 'Alfa Romeo'}
-}

--- a/fastf1/_api.py
+++ b/fastf1/_api.py
@@ -1237,7 +1237,7 @@ def track_status_data(path, response=None, livedata=None):
     if livedata is not None and livedata.has('TrackStatus'):
         # does not need any further processing
         _logger.info("Loading track status data")
-        return livedata.get('TrackStatus')
+        response = livedata.get('TrackStatus')
     elif response is None:
         _logger.info("Fetching track status data...")
         response = fetch_page(path, 'track_status')
@@ -1293,7 +1293,7 @@ def session_status_data(path, response=None, livedata=None):
     if livedata is not None and livedata.has('SessionStatus'):
         # does not need any further processing
         _logger.info("Loading session status data")
-        return livedata.get('SessionStatus')
+        response = livedata.get('SessionStatus')
     elif response is None:
         _logger.info("Fetching session status data...")
         response = fetch_page(path, 'session_status')
@@ -1364,7 +1364,7 @@ def race_control_messages(path, response=None, livedata=None):
     if livedata is not None and livedata.has('RaceControlMessages'):
         # does not need any further processing
         _logger.info("Loading race control messages")
-        return livedata.get('RaceControlMessages')
+        response = livedata.get('RaceControlMessages')
     elif response is None:
         _logger.info("Fetching race control messages...")
         response = fetch_page(path, 'race_control_messages')

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1756,6 +1756,8 @@ class Session:
                 'IsAccurate': [False]
             })
 
+            self._add_track_status_to_laps(new_last)
+
             # add generated laps at the end and fix sorting at the end
             self._laps = (pd.concat([self._laps, new_last])
                           .__finalize__(self._laps))

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -2475,6 +2475,12 @@ class Session:
         See :class:`~fastf1.mvapi.CircuitInfo` for detailed information.
         """
         circuit_key = self.session_info['Meeting']['Circuit']['Key']
+
+        if ((circuit_key == 149)
+                and (self.session_info['Meeting']['Circuit']['ShortName']
+                     == 'Mugello')):
+            circuit_key = 146
+
         circuit_info = get_circuit_info(year=self.event.year,
                                         circuit_key=circuit_key)
         circuit_info.add_marker_distance(

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1503,7 +1503,7 @@ class Session:
                     result.reset_index(drop=True, inplace=True)
                     result['Driver'] = [driver, ]
                     result['NumberOfLaps'] = 1
-                    result['Time'] = data['Time'].min()
+                    result['Time'] = pd.NaT
                     result['IsPersonalBest'] = False
                     result['Compound'] = d2['Compound'].iloc[0]
                     result['TyreLife'] = d2['StartLaps'].iloc[0]
@@ -1631,6 +1631,8 @@ class Session:
 
                 # number positions and restore previous order by index
                 laps_eq_n['Position'] = range(1, len(laps_eq_n) + 1)
+                #asign NaN to laps with NaT times
+                laps_eq_n[laps_eq_n['Time'].isnull()]['Position'] = np.NaN
                 laps.loc[laps['LapNumber'] == lap_n, 'Position'] \
                     = laps_eq_n.sort_index()['Position'].to_list()
 

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1602,7 +1602,6 @@ class Session:
         if df is None:
             raise NoLapDataError
 
-
         laps = df.reset_index(drop=True)  # noqa: F821
 
         # rename some columns

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1472,16 +1472,10 @@ class Session:
             # no driver list, generate from lap data
             drivers = set(data['Driver'].unique()) \
                 .intersection(set(useful['Driver'].unique()))
-
             _nums_df = pd.DataFrame({'DriverNumber': list(drivers)},
                                     index=list(drivers))
-            _info_df = pd.DataFrame(fastf1._DRIVER_TEAM_MAPPING).T
-
-            self._results = SessionResults(_nums_df.join(_info_df),
-                                           force_default_cols=True)
-
-            _logger.warning("Generating minimal driver "
-                            "list from timing data.")
+            self._results = SessionResults(_nums_df, force_default_cols=True)
+            _logger.warning("Generating minimal driver list from timing data.")
 
         df = None
         for _, driver in enumerate(drivers):
@@ -2191,21 +2185,24 @@ class Session:
         # set results from either source or join if both data is available
         # use driver info from F1 as primary source, only fall back to Ergast
         # if unavailable
-        # use results from Ergast, unavailable from F1 API
+        # use results from Ergast, if data is unavailable from F1 API
+
+        no_driver_info_f1 = (driver_info_f1 is None) or driver_info_f1.empty
+        no_driver_info_ergast \
+            = (driver_info_ergast is None) or driver_info_ergast.empty
 
         # no data
-        if (driver_info_f1 is None) and (driver_info_ergast is None):  # LP1
-            _logger.warning("Failed to load driver list and "
-                            "session results!")
+        if no_driver_info_f1 and no_driver_info_ergast:
+            _logger.warning("Failed to load driver list and session results!")
             self._results = SessionResults(force_default_cols=True)
 
         # only Ergast data
-        elif driver_info_f1 is None:  # LP2
+        elif no_driver_info_f1:  # LP2
             self._results = SessionResults(driver_info_ergast,
                                            force_default_cols=True)
 
         # only F1 data
-        elif driver_info_ergast is None:  # LP3
+        elif no_driver_info_ergast:
             self._results = SessionResults(driver_info_f1,
                                            force_default_cols=True)
 
@@ -2251,21 +2248,38 @@ class Session:
             driver_info = {}
         else:
             driver_info = collections.defaultdict(list)
+
             for key1, key2 in {
-                'RacingNumber': 'DriverNumber',
                 'BroadcastName': 'BroadcastName',
-                'Tla': 'Abbreviation', 'TeamName': 'TeamName',
-                'TeamColour': 'TeamColor', 'FirstName': 'FirstName',
-                'LastName': 'LastName', 'HeadshotUrl': 'HeadshotUrl',
+                'Tla': 'Abbreviation',
+                'TeamName': 'TeamName',
+                'TeamColour': 'TeamColor',
+                'FirstName': 'FirstName',
+                'LastName': 'LastName',
+                'HeadshotUrl': 'HeadshotUrl',
                 'CountryCode': 'CountryCode'
             }.items():
                 for entry in f1di.values():
                     driver_info[key2].append(entry.get(key1))
+
+            # special case for driver number which seems to be duplicated and
+            # is used as dictionary key as well; use explicit racing number
+            # property when available, else fallback to using dict key
+            for key, entry in f1di.items():
+                driver_info['DriverNumber'].append(
+                    entry.get('RacingNumber') or key
+                )
+
             if 'FirstName' in driver_info and 'LastName' in driver_info:
                 for first, last in zip(driver_info['FirstName'],
                                        driver_info['LastName']):
                     driver_info['FullName'].append(f"{first} {last}")
-        return pd.DataFrame(driver_info, index=driver_info['DriverNumber'])
+
+        # driver info is required for joining on index (used as index),
+        # therefore drop rows where driver number is unavailable as they have
+        # an invalid index
+        return pd.DataFrame(driver_info, index=driver_info['DriverNumber']) \
+            .dropna(subset=['DriverNumber'])
 
     def _drivers_results_from_ergast(
             self, *, load_drivers=False, load_results=False

--- a/fastf1/mvapi/data.py
+++ b/fastf1/mvapi/data.py
@@ -135,7 +135,8 @@ def get_circuit_info(*, year: int, circuit_key: int) -> Optional[CircuitInfo]:
     ret = list()
     for cat in ('corners', 'marshalLights', 'marshalSectors'):
         rows = list()
-        for entry in data[cat]:
+        array = data.get(cat) or list()
+        for entry in array:
             rows.append((
                 float(entry.get('trackPosition', {}).get('x', 0.0)),
                 float(entry.get('trackPosition', {}).get('y', 0.0)),

--- a/fastf1/signalr_aio/transports/_transport.py
+++ b/fastf1/signalr_aio/transports/_transport.py
@@ -93,6 +93,15 @@ class Transport:
         for task in pending:
             task.cancel()
 
+        try:
+            consumer_exception = consumer_task.exception()
+        except asyncio.CancelledError:
+            pass
+        else:
+            if not isinstance(consumer_exception,
+                              websockets.exceptions.ConnectionClosedOK):
+                raise consumer_exception
+
     async def _consumer_handler(self, ws):
         while True:
             message = await ws.recv()

--- a/fastf1/tests/test_livetiming.py
+++ b/fastf1/tests/test_livetiming.py
@@ -25,16 +25,18 @@ def test_file_loading():
 def test_duplicate_removal(tmpdir):
     # create a temporary file with two identical lines of data
     tmpfile = os.path.join(tmpdir, 'tmpfile.txt')
+    tmpfile2 = os.path.join(tmpdir, 'tmpfile2.txt')
+
     data = "['TimingAppData', {'Lines': {'22': {'Stints': {'0': {" \
            "'LapFlags': 0, 'Compound': 'UNKNOWN', 'New': 'false'," \
            "'TyresNotChanged': '0', 'TotalLaps': 0, 'StartLaps':" \
            "0}}}}}, '2021-03-27T12:00:32.086Z']\n"
+
     with open(tmpfile, 'w') as fobj:
         fobj.write(data)
+
+    with open(tmpfile2, 'w') as fobj:
         fobj.write(data)
 
-    livedata = LiveTimingData(tmpfile)
+    livedata = LiveTimingData(tmpfile, tmpfile2)
     assert len(livedata.get('TimingAppData')) == 1
-
-    livedata = LiveTimingData(tmpfile, remove_duplicates=False)
-    assert len(livedata.get('TimingAppData')) == 2


### PR DESCRIPTION
There is a special case in _load_laps_data to create data for drivers crashed in lap1. In that, previously we were assigning `data['Time'].min()` this was the source of the bug. 

I modified two things:
assign time as pd.NaT for crashed drivers.

And while generating the position of drivers for the lap, assign np.NaN to drivers who have NaT/NaN times.