### PR TITLE
Remove _DRIVER_TEAM_MAPPING in __init__.py

### DIFF
--- a/fastf1/__init__.py
+++ b/fastf1/__init__.py
@@ -102,9 +102,6 @@ if __version_tuple__:
 else:
     __version_short__ = __version__
 
-
-from typing import Dict
-
 from fastf1.events import get_session  # noqa: F401
 from fastf1.events import (  # noqa: F401
     get_event,
@@ -118,51 +115,3 @@ from fastf1.req import (  # noqa: F401
     Cache,
     RateLimitExceededError
 )
-
-
-_DRIVER_TEAM_MAPPING: Dict[str, Dict[str, str]] = {
-    # only necessary when loading live timing data that does not include
-    # the driver and team listing and no data is available on ergast yet
-    '23': {'Abbreviation': 'ALB', 'FirstName': 'Alexander',
-           'LastName': 'Albon', 'TeamName': 'Williams'},
-    '14': {'Abbreviation': 'ALO', 'FirstName': 'Fernando',
-           'LastName': 'Alonso', 'TeamName': 'Alpine F1 Team'},
-    '77': {'Abbreviation': 'BOT', 'FirstName': 'Valtteri',
-           'LastName': 'Bottas', 'TeamName': 'Alfa Romeo'},
-    '10': {'Abbreviation': 'GAS', 'FirstName': 'Pierre',
-           'LastName': 'Gasly', 'TeamName': 'AlphaTauri'},
-    '44': {'Abbreviation': 'HAM', 'FirstName': 'Lewis',
-           'LastName': 'Hamilton', 'TeamName': 'Mercedes'},
-    '27': {'Abbreviation': 'HUL', 'FirstName': 'Nico',
-           'LastName': 'Hülkenberg', 'TeamName': 'Aston Martin'},
-    '6': {'Abbreviation': 'LAT', 'FirstName': 'Nicholas',
-          'LastName': 'Latifi', 'TeamName': 'Williams'},
-    '16': {'Abbreviation': 'LEC', 'FirstName': 'Charles',
-           'LastName': 'Leclerc', 'TeamName': 'Ferrari'},
-    '20': {'Abbreviation': 'MAG', 'FirstName': 'Kevin',
-           'LastName': 'Magnussen', 'TeamName': 'Haas F1 Team'},
-    '4': {'Abbreviation': 'NOR', 'FirstName': 'Lando',
-          'LastName': 'Norris', 'TeamName': 'McLaren'},
-    '31': {'Abbreviation': 'OCO', 'FirstName': 'Esteban',
-           'LastName': 'Ocon', 'TeamName': 'Alpine F1 Team'},
-    '11': {'Abbreviation': 'PER', 'FirstName': 'Sergio',
-           'LastName': 'Pérez', 'TeamName': 'Red Bull'},
-    '3': {'Abbreviation': 'RIC', 'FirstName': 'Daniel',
-          'LastName': 'Ricciardo', 'TeamName': 'McLaren'},
-    '63': {'Abbreviation': 'RUS', 'FirstName': 'George',
-           'LastName': 'Russell', 'TeamName': 'Mercedes'},
-    '55': {'Abbreviation': 'SAI', 'FirstName': 'Carlos',
-           'LastName': 'Sainz', 'TeamName': 'Ferrari'},
-    '47': {'Abbreviation': 'MSC', 'FirstName': 'Mick',
-           'LastName': 'Schumacher', 'TeamName': 'Haas F1 Team'},
-    '18': {'Abbreviation': 'STR', 'FirstName': 'Lance',
-           'LastName': 'Stroll', 'TeamName': 'Aston Martin'},
-    '22': {'Abbreviation': 'TSU', 'FirstName': 'Yuki',
-           'LastName': 'Tsunoda', 'TeamName': 'AlphaTauri'},
-    '1': {'Abbreviation': 'VER', 'FirstName': 'Max',
-          'LastName': 'Verstappen', 'TeamName': 'Red Bull'},
-    '5': {'Abbreviation': 'VET', 'FirstName': 'Sebastian',
-          'LastName': 'Vettel', 'TeamName': 'Aston Martin'},
-    '24': {'Abbreviation': 'ZHO', 'FirstName': 'Guanyu',
-           'LastName': 'Zhou', 'TeamName': 'Alfa Romeo'}
-}

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1469,19 +1469,7 @@ class Session:
 
         drivers = self.drivers
         if not drivers:
-            # no driver list, generate from lap data
-            drivers = set(data['Driver'].unique()) \
-                .intersection(set(useful['Driver'].unique()))
-
-            _nums_df = pd.DataFrame({'DriverNumber': list(drivers)},
-                                    index=list(drivers))
-            _info_df = pd.DataFrame(fastf1._DRIVER_TEAM_MAPPING).T
-
-            self._results = SessionResults(_nums_df.join(_info_df),
-                                           force_default_cols=True)
-
-            _logger.warning("Generating minimal driver "
-                            "list from timing data.")
+            pass
 
         df = None
         for _, driver in enumerate(drivers):


### PR DESCRIPTION
Reference: #587 

Thoughts on the appropriate exception to raise when we encounter this edge case? This relates to both the livetiming API and Ergast so raising either `SessionNotAvailableError` or `ErgastError` feels incomplete.

For the moment a blank exception might suffice since this code block is so rarely ran, to be replaced by something better when #541 is done.