### PR TITLE
[ENH] Add COL and HAD to driver dictionaries

### DIFF
--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -887,7 +887,7 @@ class EventSchedule(BaseDataFrame):
             if self[col].isna().all():
                 if _type == 'datetime64[ns]':
                     self[col] = pd.NaT
-                elif _type == object:
+                elif _type == object:  # noqa: E721, type comparison with ==
                     self[col] = None
                 else:
                     self[col] = _type()

--- a/fastf1/plotting.py
+++ b/fastf1/plotting.py
@@ -141,10 +141,12 @@ DRIVER_COLORS: Dict[str, str] = {
     "max verstappen": "#fcd700",
     "sergio perez": "#ffec7b",
     "jake dennis": "#907400",
+    "isack hadjar": "#fff5b5",
 
     "alexander albon": "#005aff",
     "logan sargeant": "#012564",
     "zak osullivan": "#1b3d97",
+    "franco colapinto": "#639aff"
 }
 """Mapping of driver names to driver colors (hex color codes).
 (current season only)"""
@@ -153,7 +155,7 @@ DRIVER_TRANSLATE: Dict[str, str] = {
     'LEC': 'charles leclerc', 'SAI': 'carlos sainz',
     'SHW': 'robert shwartzman',
     'VER': 'max verstappen', 'PER': 'sergio perez',
-    'DEN': 'jake dennis',
+    'DEN': 'jake dennis', 'HAD': 'isack hadjar',
     'PIA': 'oscar piastri', 'NOR': 'lando norris',
     'OWA': 'pato oward',
     'GAS': 'pierre gasly', 'OCO': 'esteban ocon',
@@ -170,7 +172,7 @@ DRIVER_TRANSLATE: Dict[str, str] = {
     'HAM': 'lewis hamilton', 'RUS': 'george russell',
     'VES': 'frederik vesti',
     'ALB': 'alexander albon', 'SAR': 'logan sargeant',
-    'OSU': 'zak osullivan'}
+    'OSU': 'zak osullivan', 'COL': 'franco colapinto'}
 """Mapping of driver names to theirs respective abbreviations."""
 
 COMPOUND_COLORS: Dict[str, str] = {

--- a/fastf1/plotting.py
+++ b/fastf1/plotting.py
@@ -141,7 +141,6 @@ DRIVER_COLORS: Dict[str, str] = {
     "max verstappen": "#fcd700",
     "sergio perez": "#ffec7b",
     "jake dennis": "#907400",
-    "isack hadjar": "#fff5b5",
 
     "alexander albon": "#005aff",
     "logan sargeant": "#012564",
@@ -155,7 +154,7 @@ DRIVER_TRANSLATE: Dict[str, str] = {
     'LEC': 'charles leclerc', 'SAI': 'carlos sainz',
     'SHW': 'robert shwartzman',
     'VER': 'max verstappen', 'PER': 'sergio perez',
-    'DEN': 'jake dennis', 'HAD': 'isack hadjar',
+    'DEN': 'jake dennis',
     'PIA': 'oscar piastri', 'NOR': 'lando norris',
     'OWA': 'pato oward',
     'GAS': 'pierre gasly', 'OCO': 'esteban ocon',


### PR DESCRIPTION
Franco Colapinto (COL) and Isack Hadjar (HAD) participated in FP1 at Silverstone for Williams and Red Bull, respectively. Bearman also participated for Haas, but he already has a colour from previously driving for Ferrari so I left it as is for him. 

I spent very little time choosing the colours, feel free to pick something else. 

![image](https://github.com/theOehrly/Fast-F1/assets/9819480/c111d761-71bc-4965-a37b-bcd3d0af5f38)
