### PR TITLE
Enhance add_sorted_driver_legend

### DIFF
--- a/fastf1/plotting/_interface.py
+++ b/fastf1/plotting/_interface.py
@@ -752,11 +752,17 @@ def add_sorted_driver_legend(
     dtm = _get_driver_team_mapping(session)
 
     try:
-        handles, labels, kwargs \
-            = matplotlib.legend._parse_legend_args([ax], *args, **kwargs)
+        ret = matplotlib.legend._parse_legend_args([ax], *args, **kwargs)
+        if len(ret) == 3:
+            handles, labels, kwargs = ret
+            extra_args = []
+        else:
+            handles, labels, extra_args, kwargs = ret
+
     except AttributeError:
         warnings.warn("Failed to parse optional legend arguments correctly.",
                       UserWarning)
+        extra_args = []
         kwargs.pop('handles', None)
         kwargs.pop('labels', None)
         handles, labels = ax.get_legend_handles_labels()
@@ -788,7 +794,7 @@ def add_sorted_driver_legend(
         handles_new.append(elem[2])
         labels_new.append(elem[3])
 
-    return ax.legend(handles_new, labels_new, **kwargs)
+    return ax.legend(handles_new, labels_new, *extra_args, **kwargs)
 
 
 def set_default_colormap(colormap: str):

--- a/fastf1/plotting/_interface.py
+++ b/fastf1/plotting/_interface.py
@@ -717,7 +717,9 @@ def list_compounds(session: Session) -> List[str]:
     return list(_Constants[year].CompoundColors.keys())
 
 
-def add_sorted_driver_legend(ax: matplotlib.axes.Axes, session: Session, *args, **kwargs):
+def add_sorted_driver_legend(
+    ax: matplotlib.axes.Axes, session: Session, *args, **kwargs
+):
     """
     Adds a legend to the axis where drivers are grouped by team and within each
     team they are shown in the same order that is used for selecting plot

--- a/fastf1/plotting/_interface.py
+++ b/fastf1/plotting/_interface.py
@@ -717,7 +717,7 @@ def list_compounds(session: Session) -> List[str]:
     return list(_Constants[year].CompoundColors.keys())
 
 
-def add_sorted_driver_legend(ax: matplotlib.axes.Axes, session: Session):
+def add_sorted_driver_legend(ax: matplotlib.axes.Axes, session: Session, *args, **kwargs):
     """
     Adds a legend to the axis where drivers are grouped by team and within each
     team they are shown in the same order that is used for selecting plot
@@ -767,11 +767,14 @@ def add_sorted_driver_legend(ax: matplotlib.axes.Axes, session: Session):
 
     handles_new = list()
     labels_new = list()
+    seen_labels = set()
     for elem in ref:
-        handles_new.append(elem[2])
-        labels_new.append(elem[3])
+        if elem[3] not in seen_labels:
+            handles_new.append(elem[2])
+            labels_new.append(elem[3])
+            seen_labels.add(elem[3])
 
-    return ax.legend(handles_new, labels_new)
+    return ax.legend(handles_new, labels_new, *args, **kwargs)
 
 
 def set_default_colormap(colormap: str):

--- a/fastf1/plotting/_interface.py
+++ b/fastf1/plotting/_interface.py
@@ -735,6 +735,8 @@ def add_sorted_driver_legend(
     Args:
         ax: An instance of a Matplotlib ``Axes`` object
         session: the session for which the data should be obtained
+        *args: Matplotlib legend args
+        **kwargs: Matplotlib legend kwargs
 
      Returns:
         ``matplotlib.legend.Legend``

--- a/fastf1/tests/test_plotting.py
+++ b/fastf1/tests/test_plotting.py
@@ -452,3 +452,12 @@ def test_override_team_constants():
 
     if fastf1.plotting.get_team_name('Haas', session, short=True) != 'Haas':
         raise RuntimeError("Test cleanup failed!")
+
+
+def test_import_internal_mpl_lgend_arg_kwarg_parser():
+    # Import the module and just try to access the internal function to see
+    # if it is available. This is not a test of the function itself but rather
+    # serves as an early warning if the function is removed or renamed by
+    # causing a test failure.
+    import matplotlib.legend
+    _ = matplotlib.legend._parse_legend_args


### PR DESCRIPTION
It would be useful if the function fastf1.plotting.add_sorted_driver_legend(ax, term) included the same arguments as the Matplotlib function ax.legend(), such as loc, fontsize...

Another improvement would be to ensure a unique list of labels