### PR TITLE
Rename `visa_rb` key to `rb`

### DIFF
--- a/fastf1/plotting/__init__.py
+++ b/fastf1/plotting/__init__.py
@@ -5,6 +5,8 @@ from fastf1.plotting._constants import \
 from fastf1.plotting._constants import \
     LEGACY_DRIVER_TRANSLATE as _LEGACY_DRIVER_TRANSLATE
 from fastf1.plotting._constants import \
+    LEGACY_TEAM_COLORS as _LEGACY_TEAM_COLORS
+from fastf1.plotting._constants import \
     LEGACY_TEAM_TRANSLATE as _LEGACY_TEAM_TRANSLATE
 from fastf1.plotting._constants import Constants as _Constants
 from fastf1.plotting._interface import (  # noqa: F401
@@ -134,12 +136,7 @@ Mapping of driver names to theirs respective abbreviations.
     future version. Use :func:`~fastf1.plotting.get_driver_name` instead.
 """
 
-_DEPR_TEAM_COLORS: dict[str, str] = {
-    # str(key.value): val for key, val
-    # in _Constants['2024'].Colormaps[_Colormaps.Default].items()
-    name.replace("kick ", ""): team.TeamColor.FastF1 for name, team
-    in _Constants['2024'].Teams.items()
-}
+_DEPR_TEAM_COLORS: dict[str, str] = _LEGACY_TEAM_COLORS.copy()
 TEAM_COLORS: dict[str, str]
 """
 Mapping of team names to team colors (hex color codes).

--- a/fastf1/plotting/_constants/__init__.py
+++ b/fastf1/plotting/_constants/__init__.py
@@ -38,7 +38,7 @@ LEGACY_TEAM_TRANSLATE: dict[str, str] = {
     'APN': 'alpine',
     'AMR': 'aston martin',
     'SAU': 'sauber',
-    'RB': 'rb',
+    'RB' : 'visa rb',
     'HAA': 'haas',
     'WIL': 'williams'
 }

--- a/fastf1/plotting/_plotting.py
+++ b/fastf1/plotting/_plotting.py
@@ -176,18 +176,23 @@ def driver_color(identifier: str) -> str:
             ratio = fuzz.ratio(identifier, existing_key)
             key_ratios.append((ratio, existing_key))
         key_ratios.sort(reverse=True)
-        if key_ratios[0][0] != 100:
-            _logger.warning(
-                "Correcting invalid user input "
-                 f"'{identifier}' to '{key_ratios[0][1]}'."
 
-            )
-        if ((key_ratios[0][0] < 35)
-                or (key_ratios[0][0] / key_ratios[1][0] < 1.2)):
+        if (key_ratios[0][0] < 35) or (
+            key_ratios[0][0] / key_ratios[1][0] < 1.2
+        ):
             # ensure that the best match has a minimum accuracy (35 out of
             # 100) and that it has a minimum confidence (at least 20% better
             # than second best)
-            raise KeyError
+            raise KeyError(
+                f"Cannot find a good match for user input: {identifier}"
+            )
+
+        if key_ratios[0][0] != 100:
+            _logger.warning(
+                "Correcting invalid user input "
+                f"'{identifier}' to '{key_ratios[0][1]}'."
+            )
+
         best_matched_key = key_ratios[0][1]
         return LEGACY_DRIVER_COLORS[best_matched_key]
 
@@ -263,18 +268,22 @@ def team_color(identifier: str) -> str:
             ratio = fuzz.ratio(identifier, existing_key)
             key_ratios.append((ratio, existing_key))
         key_ratios.sort(reverse=True)
-        if key_ratios[0][0] != 100:
-            _logger.warning(
-                "Correcting invalid user input "
-                 f"'{identifier}' to '{key_ratios[0][1]}'."
 
-            )
-        if ((key_ratios[0][0] < 35)
-                or (key_ratios[0][0] / key_ratios[1][0] < 1.2)):
+        if (key_ratios[0][0] < 35) or (
+            key_ratios[0][0] / key_ratios[1][0] < 1.2
+        ):
             # ensure that the best match has a minimum accuracy (35 out of
             # 100) and that it has a minimum confidence (at least 20% better
             # than second best)
-            raise KeyError
+            raise KeyError(
+                f"Cannot find a good match for user input: {identifier}"
+            )
+
+        if key_ratios[0][0] != 100:
+            _logger.warning(
+                "Correcting invalid user input "
+                f"'{identifier}' to '{key_ratios[0][1]}'."
+            )
         best_matched_key = key_ratios[0][1]
         return LEGACY_TEAM_COLORS[best_matched_key]
 

--- a/fastf1/tests/test_plotting_deprecated.py
+++ b/fastf1/tests/test_plotting_deprecated.py
@@ -102,11 +102,20 @@ def test_driver_color():
 
 def test_team_color():
     with pytest.warns(FutureWarning, match="is deprecated"):
-        color = fastf1.plotting.team_color('ferrari')
+        color_ferrari = fastf1.plotting.team_color('ferrari')
 
-    assert color.startswith('#')
-    assert len(color) == 7
-    _ = int(color[1:], base=16)  # ensure that it's a valid hex color
+    assert color_ferrari.startswith('#')
+    assert len(color_ferrari) == 7
+    _ = int(color_ferrari[1:], base=16)  # ensure that it's a valid hex color
+
+    with pytest.warns(FutureWarning, match="is deprecated"):
+        color_visa = fastf1.plotting.team_color("visa")
+        color_rb = fastf1.plotting.team_color("rb")
+        color_visa_rb = fastf1.plotting.team_color("visa rb")
+        color_rbr = fastf1.plotting.team_color("RBR")
+    
+    assert color_visa == color_rb == color_visa_rb
+    assert color_visa_rb != color_rbr
 
 
 def test_lapnumber_axis():


### PR DESCRIPTION
Fixes #644

I am choosing to change the team colors dictionary rather than the team translate dictionary because `visa rb` is not how the team is represented in the data