### PR TITLE
chore: Incompatibility with websockets 14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "scipy>=1.8.1,<2.0.0",
   "rapidfuzz",
   "timple>=0.1.6",
-  "websockets>=10.3",
+  "websockets>=10.3,<14",
 ]
 
 [project.urls]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ wheel
 xdoctest
 pre-commit
 requests>=2.28.1
-websockets>=10.3
+websockets>=10.3,<14
 seaborn
 plotly
 seaborn


### PR DESCRIPTION
Temporary workaround to pin websocket <14, as v14 updates the `connect()` api.
https://websockets.readthedocs.io/en/stable/howto/upgrade.html#arguments-of-connect

https://github.com/theOehrly/Fast-F1/blob/0fabc0688fd8c5583f2061946aeca26078aa1255/fastf1/signalr_aio/transports/_transport.py#L82

error
```
future: <Task finished name='Task-40' coro=<Transport._socket() done, defined at /.venv/lib/python3.12/site-packages/fastf1/signalr_aio/transports/_transport.py:81> exception=TypeError("BaseEventLoop.create_connection() got an unexpected keyword argument 'extra_headers'")>"}
2024-11-23T14:19:30.119+08:00
Traceback (most recent call last):
2024-11-23T14:19:30.119+08:00
File "/.venv/lib/python3.12/site-packages/fastf1/signalr_aio/transports/_transport.py", line 82, in _socket
2024-11-23T14:19:30.119+08:00
async with websockets.connect(self._ws_params.socket_url, extra_headers=self._ws_params.headers,
2024-11-23T14:19:30.119+08:00
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-23T14:19:30.119+08:00
File "/.venv/lib/python3.12/site-packages/websockets/asyncio/client.py", line 485, in __aenter__
2024-11-23T14:19:30.119+08:00
return await self
2024-11-23T14:19:30.119+08:00
^^^^^^^^^^
2024-11-23T14:19:30.119+08:00
File "/.venv/lib/python3.12/site-packages/websockets/asyncio/client.py", line 442, in __await_impl__
2024-11-23T14:19:30.119+08:00
self.connection = await self.create_connection()
2024-11-23T14:19:30.119+08:00
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-23T14:19:30.119+08:00
File "/.venv/lib/python3.12/site-packages/websockets/asyncio/client.py", line 368, in create_connection
2024-11-23T14:19:30.119+08:00
_, connection = await loop.create_connection(factory, **kwargs)
2024-11-23T14:19:30.119+08:00
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-23T14:19:30.119+08:00
TypeError: BaseEventLoop.create_connection() got an unexpected keyword argument 'extra_headers'
```