### PR TITLE
Deduplicate and sort dev requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,20 +4,15 @@ isort
 kaleido
 plotly
 pre-commit
-pytest>=6.0.0  # equals pytest min version requirement
 pytest-mpl==0.14.0  # logging issues in newer versions
+pytest>=6.0.0  # equals pytest min version requirement
 requests-mock
+requests>=2.28.1
 ruff
 seaborn>0.13.0
-sphinx>6.0,<7.3
 sphinx-autodoc-typehints
 sphinx-gallery>=0.10.0
+sphinx>6.0,<7.3
+websockets>=10.3,<14
 wheel
 xdoctest
-pre-commit
-requests>=2.28.1
-websockets>=10.3,<14
-seaborn
-plotly
-seaborn
-kaleido


### PR DESCRIPTION
Stumbled across this file while investigating #674. It contains some duplicate requirements that are probably unintended results of merges.

Just ran `sort -u` on it