### PR TITLE
Fix setting timedelta on datetime array

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1551,7 +1551,8 @@ class Session:
                 laps_start_time.insert(0, self.session_start_time)
             else:
                 laps_start_time.insert(0, pd.NaT)
-            laps_start_time = pd.Series(laps_start_time, dtype="timedelta64[ns]")
+            laps_start_time = pd.Series(laps_start_time,
+                                        dtype="timedelta64[ns]")
 
             # don't set lap start times after red flag restart to the time
             # at which the previous lap was set

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1551,7 +1551,7 @@ class Session:
                 laps_start_time.insert(0, self.session_start_time)
             else:
                 laps_start_time.insert(0, pd.NaT)
-            laps_start_time = pd.Series(laps_start_time)
+            laps_start_time = pd.Series(laps_start_time, dtype="timedelta64[ns]")
 
             # don't set lap start times after red flag restart to the time
             # at which the previous lap was set
@@ -1590,9 +1590,7 @@ class Session:
                     elif row['Status'] == 'Aborted':  # red flag
                         _is_aborted = True
 
-            result.loc[:, 'LapStartTime'] = pd.Series(
-                laps_start_time, dtype='timedelta64[ns]'
-            )
+            result['LapStartTime'] = laps_start_time
 
             # set missing lap start times to pit out time, where possible
             mask = (pd.isna(result['LapStartTime'])


### PR DESCRIPTION
See #674 for discussion on the cause of the bug. The solution is to make sure `laps_start_time` get correct data type when it is converted back to a series