### PR TITLE
Add team colors for 2025 season

### DIFF
--- a/fastf1/plotting/_constants/__init__.py
+++ b/fastf1/plotting/_constants/__init__.py
@@ -5,14 +5,15 @@ from fastf1.plotting._constants import (  # noqa: F401, unused import used throu
     season2021,
     season2022,
     season2023,
-    season2024
+    season2024,
+    season2025
 )
 from fastf1.plotting._constants.base import BaseSeasonConst
 
 
 Constants: dict[str, BaseSeasonConst] = dict()
 
-for year in range(2018, 2025):
+for year in range(2018, 2026):
     season = globals()[f"season{year}"]
     Constants[str(year)] = BaseSeasonConst(
         CompoundColors=season.CompoundColors,

--- a/fastf1/plotting/_constants/season2025.py
+++ b/fastf1/plotting/_constants/season2025.py
@@ -1,0 +1,94 @@
+
+from fastf1.plotting._constants.base import (
+    CompoundsConst,
+    TeamColorsConst,
+    TeamConst
+)
+
+
+# NOTE: the team constants are copied when loading the driver-team-mapping
+# and values may be modified there, if the used API provides different values
+
+
+Teams: dict[str, TeamConst] = {
+    'alpine': TeamConst(
+        ShortName='Alpine',
+        TeamColor=TeamColorsConst(
+            Official='#0093cc',
+            FastF1='#ff87bc'
+        )
+    ),
+    'aston martin': TeamConst(
+        ShortName='Aston Martin',
+        TeamColor=TeamColorsConst(
+            Official='#229971',
+            FastF1='#00665f'
+        )
+    ),
+    'ferrari': TeamConst(
+        ShortName='Ferrari',
+        TeamColor=TeamColorsConst(
+            Official='#e80020',
+            FastF1='#e80020'
+        )
+    ),
+    'haas': TeamConst(
+        ShortName='Haas',
+        TeamColor=TeamColorsConst(
+            Official='#b6babd',
+            FastF1='#b6babd'
+        )
+    ),
+    'mclaren': TeamConst(
+        ShortName='McLaren',
+        TeamColor=TeamColorsConst(
+            Official='#ff8000',
+            FastF1='#ff8000'
+        )
+    ),
+    'mercedes': TeamConst(
+        ShortName='Mercedes',
+        TeamColor=TeamColorsConst(
+            Official='#27f4d2',
+            FastF1='#27f4d2'
+        )
+    ),
+    'racing bulls': TeamConst(
+        ShortName='RB',
+        TeamColor=TeamColorsConst(
+            Official='#6692ff',
+            FastF1='#e80020'
+        )
+    ),
+    'red bull': TeamConst(
+        ShortName='Red Bull',
+        TeamColor=TeamColorsConst(
+            Official='#3671c6',
+            FastF1='#0600ef'
+        )
+    ),
+    'kick sauber': TeamConst(
+        ShortName='Sauber',
+        TeamColor=TeamColorsConst(
+            Official='#52e252',
+            FastF1='#00e700'
+        )
+    ),
+    'williams': TeamConst(
+        ShortName='Williams',
+        TeamColor=TeamColorsConst(
+            Official='#64c4ff',
+            FastF1='#00a0dd'
+        )
+    )
+}
+
+CompoundColors: dict[CompoundsConst, str] = {
+    CompoundsConst.Soft: "#da291c",
+    CompoundsConst.Medium: "#ffd12e",
+    CompoundsConst.Hard: "#f0f0ec",
+    CompoundsConst.Intermediate: "#43b02a",
+    CompoundsConst.Wet: "#0067ad",
+    CompoundsConst.Unknown: "#00ffff",
+    CompoundsConst.TestUnknown: "#434649"
+}


### PR DESCRIPTION
Went through the API output and updated the official colors accordingly.

Only Ferrari's color changed slightly, updated the Fastf1 scheme to match as well.

No changes compared to the 2024 colors otherwise. RB's color perhaps need revisiting as the current bluish hue is not very representative of their livery.

Closes #689 