### PR TITLE
Update readme to link to jolpica-f1 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ schedules, timing data and telemetry.
 ## Main Features
 
 - Access to F1 timing data, telemetry, sessions results and more
-- Full support for [Ergast](http://ergast.com/mrd/) to access current and
+- Full support for the Ergast compatible [jolpica-f1](https://github.com/jolpica/jolpica-f1/blob/main/docs/README.md) API to access current and
   historical F1 data
 - All data is provided in the form of extended Pandas DataFrames to make
   working with the data easy while having powerful tools available


### PR DESCRIPTION
Since the project is now using [api.jolpi.ca](https://github.com/theOehrly/Fast-F1/blob/f3906e15149e735f840e7f62dc39a2a4fc324685/fastf1/ergast/interface.py#L18) by default, it may make sense to update the readme.