### PR TITLE
fix: VCARB color for 2025

### DIFF
--- a/fastf1/plotting/_constants/season2025.py
+++ b/fastf1/plotting/_constants/season2025.py
@@ -57,7 +57,7 @@ Teams: dict[str, TeamConst] = {
         ShortName='RB',
         TeamColor=TeamColorsConst(
             Official='#6692ff',
-            FastF1='#e80020'
+            FastF1='#fcd700'
         )
     ),
     'red bull': TeamConst(


### PR DESCRIPTION
The VCARB color for 2025 was red by mistake. I've changed it to yellow like last year