### PR TITLE
Proper initiation of NaT as timedelta type

### DIFF
--- a/fastf1/_api.py
+++ b/fastf1/_api.py
@@ -767,7 +767,7 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
     # There is also a PitInTime if the car actually pits at the end of the
     # first lap, those need to be kept.
     if drv_data['PitInTime'][0] < drv_data['PitOutTime'][0]:
-        drv_data['PitInTime'][0] = pd.NaT
+        drv_data["PitInTime"][0] = pd.NaT
 
     if integrity_errors:
         _logger.warning(

--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -746,7 +746,7 @@ def _get_schedule_from_ergast(year) -> "EventSchedule":
                 f"{rnd.get('date', '')}T{rnd.get('time', '')}",
             ).tz_localize(None)
         except dateutil.parser.ParserError:
-            date = pd.NaT
+            date = pd.Timestamp(pd.NaT)
         data['EventDate'].append(date)
 
         if 'Sprint' in rnd:

--- a/fastf1/tests/test_laps.py
+++ b/fastf1/tests/test_laps.py
@@ -1,5 +1,6 @@
 import datetime
 
+import numpy as np
 import pandas
 import pandas as pd
 import pytest
@@ -334,7 +335,7 @@ def test_calculated_quali_results(source):
 
     # copy and delete (!) before recalculating
     ergast_results = session.results.copy()
-    session.results.loc[:, ('Q1', 'Q2', 'Q3')] = pd.NaT
+    session.results.loc[:, ('Q1', 'Q2', 'Q3')] = np.timedelta64("NaT")
 
     if source == "session_status":
         # delete precalculated split times (from api parser)
@@ -372,7 +373,7 @@ def test_quali_q3_cancelled(source):
     # that would be a better test case. The last one was the US GP in 2015, so
     # no lap data is available.
     session.session_status.drop([13, 14, 15, 16], inplace=True)
-    session.results['Q3'] = pd.NaT
+    session.results['Q3'] = np.timedelta64("NaT")
     if source == "session_status":
         # delete precalculated split times (from api parser)
         session._session_split_times = None
@@ -389,7 +390,7 @@ def test_quali_q3_cancelled(source):
     # Test _calculate_quali_like_session_results()
     # copy and delete (!) before recalculating
     orig_results = session.results.copy()
-    session.results.loc[:, ('Q1', 'Q2', 'Q3')] = pd.NaT
+    session.results.loc[:, ('Q1', 'Q2', 'Q3')] = np.timedelta64("NaT")
     session._calculate_quali_like_session_results(force=True)
 
     # Note that differences may exist if one or more drivers didn't set a


### PR DESCRIPTION
Addresses a followup report from #674 

Essentially the same bug and fix as in #682 and #676. Just need to bypass pandas inferring NaT as a datetime.

Fixes #728 