### PR TITLE
FIX: calculate explicitly missing lap times from sector times

### DIFF
--- a/fastf1/_api.py
+++ b/fastf1/_api.py
@@ -599,7 +599,7 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
             if not na_sectors:
                 drv_data['LapTime'][i] = sector_sum
             else:
-                drv_data['LapTime'][i] = np.timedelta64("NaT")
+                drv_data['LapTime'][i] = pd.NaT
 
         if i == 0:
             # only do following corrections for 2nd lap and onwards

--- a/fastf1/_api.py
+++ b/fastf1/_api.py
@@ -464,11 +464,16 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
                     drv_data[sector][lapcnt - lap_offset] = to_timedelta(val)
                     drv_data[sesst][lapcnt - lap_offset] = to_timedelta(time)
 
-        if val := recursive_dict_get(resp, 'LastLapTime', 'Value'):
-            # if 'LastLapTime' is received less than five seconds after the start of a new lap, it is still added
-            # to the last lap
-            val = to_timedelta(val)
-            if val.total_seconds() < 150:
+        if ((last_lap_time := resp.get('LastLapTime'))
+                and (val := last_lap_time.get('Value')) is not None):
+            # explicitly check whether the lap time is None, i.e. key is
+            # missing or if the value is an empty string
+
+            val = to_timedelta(val)  # empty string converts to None here!
+            # Set None values too, to explicitly differentiate the case where
+            # no information about the value is found in the source from the
+            # case here where the source indicates that no value exists.
+            if (val is None) or (val.total_seconds() < 150):
                 # laps which are longer than 150 seconds are ignored; usually this is the case between Q1, Q2 and Q3
                 # because all three qualifying sessions are one session here. Those timestamps are often wrong and
                 # sometimes associated with the wrong lap
@@ -580,9 +585,21 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
 
         # check for incorrect lap times and remove them
         # fixes GH#167 among others
-        if sector_sum > drv_data['LapTime'][i]:
+        if ((drv_data['LapTime'][i] is not None)
+                and (sector_sum > drv_data['LapTime'][i])):
             drv_data['LapTime'][i] = pd.NaT
             integrity_errors.append(i + 1)
+
+        # Lap times are initially set to NaT. If and only if an empty value is
+        # received from the API, the lap time is set to None. In this case, we
+        # try to calculate the lap time from sector times.
+        # This is not done for NaT lap times to protect against parser logic
+        # errors and values simply being incorrectly assigned.
+        if drv_data['LapTime'][i] is None:
+            if not na_sectors:
+                drv_data['LapTime'][i] = sector_sum
+            else:
+                drv_data['LapTime'][i] = np.timedelta64("NaT")
 
         if i == 0:
             # only do following corrections for 2nd lap and onwards
@@ -662,24 +679,34 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
 
     # need to go both directions once to make everything match up; also recalculate sector times
     for i in range(len(drv_data['Time']) - 1):
-        if any(pd.isnull(tst) for tst in (
-                drv_data['Time'][i], drv_data['LapTime'][i + 1],
-                drv_data['Sector1Time'][i + 1],
-                drv_data['Sector2Time'][i + 1],
-                drv_data['Sector3Time'][i + 1])):
-            continue  # lap not usable, missing critical values
+        if (pd.isnull(drv_data['Time'][i])
+                or pd.isnull(drv_data['LapTime'][i + 1])):
+            # lap not usable, missing critical values; more checks follow
+            continue
 
         if (new_time := drv_data['Time'][i] + drv_data['LapTime'][i+1]) \
                 < drv_data['Time'][i+1]:
             drv_data['Time'][i+1] = new_time
+
+        if pd.isnull(drv_data['Sector1Time'][i + 1]):
+            continue
+
         if (new_s1_time := drv_data['Time'][i]
                 + drv_data['Sector1Time'][i+1]) \
                 < drv_data['Sector1SessionTime'][i+1]:
             drv_data['Sector1SessionTime'][i+1] = new_s1_time
+
+        if pd.isnull(drv_data['Sector2Time'][i + 1]):
+            continue
+
         if (new_s2_time := drv_data['Time'][i] + drv_data['Sector1Time'][i+1]
                 + drv_data['Sector2Time'][i+1]) \
                 < drv_data['Sector2SessionTime'][i+1]:
             drv_data['Sector2SessionTime'][i+1] = new_s2_time
+
+        if pd.isnull(drv_data['Sector3Time'][i + 1]):
+            continue
+
         if (new_s3_time := drv_data['Time'][i] + drv_data['Sector1Time'][i+1]
                 + drv_data['Sector2Time'][i+1]
                 + drv_data['Sector3Time'][i+1]) \

--- a/fastf1/req.py
+++ b/fastf1/req.py
@@ -222,7 +222,7 @@ class Cache(metaclass=_MetaCache):
     """
     _CACHE_DIR = None
     # version of the api parser code (unrelated to release version number)
-    _API_CORE_VERSION = 14
+    _API_CORE_VERSION = 15
     _IGNORE_VERSION = False
     _FORCE_RENEW = False
 

--- a/fastf1/tests/test_input_data_handling.py
+++ b/fastf1/tests/test_input_data_handling.py
@@ -254,3 +254,18 @@ def test_laps_aligned_consistency(year, round_):
     _api._align_laps(laps_data, stream_data)
 
     pd.testing.assert_frame_equal(laps_data, laps_data_ref)
+
+
+@pytest.mark.f1telapi
+def test_explicitly_missing_lap_times_calculated():
+    # Russel had transponder issues in bahrain 2025, which caused the timing
+    # problems. Two lap times were missing but the source explicitly indicated
+    # {'value': ''} instead of simply skipping over the data.
+    # Check that in cases of explicitly missing lap times, where we know for
+    # sure that data wasn't just parsed incorrectly, the lap times are
+    # calculated from the sector times.
+    session = fastf1.get_session(2025, 4, 'R')
+    session.load(telemetry=False, weather=False)
+    l37 = session.laps.pick_drivers('63').pick_laps(37)
+
+    assert not l37['LapTime'].isna().any()


### PR DESCRIPTION
See #738, due to timing transponder issues, one of russels lap times was missing in Bahrain 2025.

Now, if possible, an explicitly missing lap time is calculated from sector times if these exist. This is only done if the source data explicitly indicates an empty value for the lap time in the form of ``...{'value': '', ... }``. We take this as explicit confirmation that the value is missing, and it is therefore OK to try and calculate it. It is not done in other cases where there is no information whatsoever about a lap time value.