### PR TITLE
FIX: correct example checking if drivers can still win the 2025 WDC

### DIFF
--- a/examples/plot_who_can_still_win_wdc.py
+++ b/examples/plot_who_can_still_win_wdc.py
@@ -14,12 +14,12 @@ from fastf1.ergast import Ergast
 
 
 ##############################################################################
-# For this example, we are looking at the 2023 season.
+# For this example, we are looking at the 2025 season.
 # We want to know who can theoretically still win the drivers' championship
-# after the first 15 races.
+# after the first 12 races.
 
-SEASON = 2023
-ROUND = 15
+SEASON = 2025
+ROUND = 12
 
 
 ##############################################################################
@@ -36,8 +36,8 @@ def get_drivers_standings():
 # driver wins everything left of the season.
 # https://en.wikipedia.org/wiki/List_of_Formula_One_World_Championship_points_scoring_systems
 def calculate_max_points_for_remaining_season():
-    POINTS_FOR_SPRINT = 8 + 25 + 1  # Winning the sprint, race and fastest lap
-    POINTS_FOR_CONVENTIONAL = 25 + 1  # Winning the race and fastest lap
+    POINTS_FOR_SPRINT = 8 + 25 # Winning the sprint and race
+    POINTS_FOR_CONVENTIONAL = 25 # Winning the race
 
     events = fastf1.events.get_event_schedule(SEASON, backend='ergast')
     events = events[events['RoundNumber'] > ROUND]


### PR DESCRIPTION
Since the 2025 season, fastest laps no longer award extra points.

This example has been updated to reflect the new regulation when 
calculating the maximum possible points for remaining races.

Source: [Formula 1](https://www.formula1.com/en/latest/article/fastest-lap-point-to-be-scrapped-in-2025-after-latest-fia-world-motor-sport.4pUjDzWnGRN7KVWENLc1BY)