### PR TITLE
Implement merge and join for Laps that wrap pandas DataFrame methods

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -2915,6 +2915,34 @@ class Laps(BaseDataFrame):
             instance of :class:`Telemetry`"""
         return self.get_telemetry()
 
+    def join(self, *args, **kwargs):
+        """Wraps :meth:`pandas.DataFrame.join` and adds metadata propagation.
+
+        When calling ``self.join`` metadata will be propagated from self to the
+        joined dataframe.
+        """
+        meta = dict()
+        for var in self._metadata:
+            meta[var] = getattr(self, var)
+        ret = super().join(*args, **kwargs)
+        for var, val in meta.items():
+            setattr(ret, var, val)
+        return ret
+
+    def merge(self, *args, **kwargs):
+        """Wraps :meth:`pandas.DataFrame.merge` and adds metadata propagation.
+
+        When calling ``self.merge`` metadata will be propagated from self to
+        the merged dataframe.
+        """
+        meta = dict()
+        for var in self._metadata:
+            meta[var] = getattr(self, var)
+        ret = super().merge(*args, **kwargs)
+        for var, val in meta.items():
+            setattr(ret, var, val)
+        return ret
+
     def get_telemetry(self,
                       *,
                       frequency: Union[int, Literal['original'], None] = None

--- a/fastf1/tests/test_laps.py
+++ b/fastf1/tests/test_laps.py
@@ -29,6 +29,29 @@ def test_base_class_view_laps():
     bcv = laps.base_class_view
     assert isinstance(bcv, pandas.DataFrame)
 
+def test_merging_with_metadata_propagation():
+    class Example:
+        pass
+    e = Example()
+    laps1 = fastf1.core.Laps({'example_1': (1, 2, 3, 4, 5, 6)}, session=e)
+    laps2 = fastf1.core.Laps({'example_2': (1, 2, 3, 4, 5, 6)}, session=e)
+    merged = laps1.merge(laps2, left_index=True, right_index=True)
+    assert hasattr(merged, 'session')
+    assert isinstance(merged.session, Example)
+    assert merged.session is e
+    assert all(col in merged.columns for col in ('example_1', 'example_2'))
+
+def test_joining_with_metadata_propagation():
+    class Example:
+        pass
+    e = Example()
+    laps1 = fastf1.core.Laps({'example_1': (1, 2, 3, 4, 5, 6)}, session=e)
+    laps2 = fastf1.core.Laps({'example_2': (1, 2, 3, 4, 5, 6)}, session=e)
+    merged = laps1.join(laps2)
+    assert hasattr(merged, 'session')
+    assert isinstance(merged.session, Example)
+    assert merged.session is e
+    assert all(col in merged.columns for col in ('example_1', 'example_2'))
 
 @pytest.mark.f1telapi
 def test_dtypes_from_api(reference_laps_data):


### PR DESCRIPTION
### What 
merge and join methods on the Laps class that are essentially identical to [those for Telemetry class](https://github.com/theOehrly/Fast-F1/blob/c5c7a98a24178062443b44dbd4a87f0ddbac1c2f/fastf1/core.py#L248-L274) , which wrap the DataFrame methods and propagate the metadata. 

### Why 
There are often scenarios where joining or merging Laps objects can be helpful. However, without propagating the metadata, certain functionality will fail on the resulting Laps. The Telemetry class already had a solution for this. This change is consistent with that. 

### Testing 
* unit tests were added similar to those for Telemetry's merge and join 
* Manual testing was also carried out  (see examples)

### Examples
An example of how to use these new methods can be found [in this notebook](https://github.com/bmedeir1/Fast-F1/blob/merge-join-laps/test_changes/test_join_merge.ipynb). 