### PR TITLE
Fix: Forward Fill missing Speedl1 and SpeedFL values

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1617,6 +1617,12 @@ class Session:
 
         self._add_track_status_to_laps(laps)
 
+        # Forward fill SpeedFL and SpeedI1 columns to fill NaN values
+        if 'SpeedFL' in laps.columns:
+            laps['SpeedFL'] = laps['SpeedFL'].ffill()
+        if 'SpeedI1' in laps.columns:
+            laps['SpeedI1'] = laps['SpeedI1'].ffill()
+
         self._laps = Laps(laps, session=self, _force_default_cols=True)
         self._check_lap_accuracy()
 


### PR DESCRIPTION
Missing values in SpeedI1 and SpeedFL columns when values are identical to previous lap. Forward fill. 

xref #775 #768 