### PR TITLE
FIX: auto cast not working in lists inside ergast raw response

### DIFF
--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -216,12 +216,23 @@ class ErgastRawResponse(ErgastResponseMixin, list):
         # has the same structure. Iterate over all elements and call the
         # recursive _auto_cast method to convert data types
         query_result = copy.deepcopy(query_result)  # TODO: efficiency?
-        for i in range(len(query_result)):
-            query_result[i] = cls._auto_cast(query_result[i], category)
+        query_result = cls._auto_cast(query_result, category)
         return query_result
 
     @classmethod
     def _auto_cast(cls, data, category):
+        # data types can be dict or list where list then contains dicts and
+        # requires iterating over each entry separately
+        if category['type'] is list:
+            for i in range(len(data)):
+                data[i] = cls._auto_cast_item(data[i], category)
+        else:
+            data = cls._auto_cast_item(data, category)
+
+        return data
+
+    @classmethod
+    def _auto_cast_item(cls, data, category):
         # convert datatypes for all known elements
         for name, mapping in category['map'].items():
             if name not in data:

--- a/fastf1/tests/test_ergast.py
+++ b/fastf1/tests/test_ergast.py
@@ -570,44 +570,128 @@ def test_ergast_result_series_constructor():
 
 def test_ergast_raw_response():
     # test auto-casting in subcategories (i.e. verify proper recursion as well)
-    data = [{
-        "circuitId": "albert_park",
-        "url": "https://...",
-        "circuitName": "Albert Park Grand Prix Circuit",
-        "Location": {"lat": "-37.8497",
-                     "long": "144.968",
-                     "locality": "Melbourne",
-                     "country": "Australia"}
-    }, {
-        "circuitId": "bahrain",
-        "url": "https://...",
-        "circuitName": "Bahrain International Circuit",
-        "Location": {"lat": "26.0325",
-                     "long": "50.5106",
-                     "locality": "Sakhir",
-                     "country": "Bahrain"}
-    }]
+    data = [
+        {
+            'season': '2025',
+            'round': '1',
+            'url': 'https://...',
+            'raceName': 'Australian Grand Prix',
+            'Circuit': {
+                'circuitId': 'albert_park',
+                'url': 'https://...',
+                'circuitName': 'Albert Park Grand Prix Circuit',
+                'Location': {
+                    'lat': '-37.8497',
+                    'long': '144.968',
+                    'locality': 'Melbourne',
+                    'country': 'Australia'
+                }
+            },
+            'date': '2025-03-16',
+            'time': '04:00:00Z',
+            'Results': [
+                {
+                    'number': '4',
+                    'position': '1',
+                    'positionText': '1',
+                    'points': '25',
+                    'Driver': {
+                        'driverId': 'norris',
+                        'permanentNumber': '4',
+                        'code': 'NOR',
+                        'url': 'http://...',
+                        'givenName': 'Lando',
+                        'familyName': 'Norris',
+                        'dateOfBirth': '1999-11-13',
+                        'nationality': 'British'
+                    },
+                    'Constructor': {
+                        'constructorId': 'mclaren',
+                        'url': 'http://...',
+                        'name': 'McLaren',
+                        'nationality': 'British'
+                    },
+                    'grid': '1',
+                    'laps': '57',
+                    'status': 'Finished',
+                    'Time': {
+                        'millis': '6126304',
+                        'time': '1:42:06.304'
+                    },
+                    'FastestLap': {
+                        'rank': '1',
+                        'lap': '43',
+                        'Time': {
+                            'time': '1:22.167'
+                        }
+                    }
+                },
+            ]
+        },
+    ]
 
-    expected = [{
-        "circuitId": "albert_park",
-        "url": "https://...",
-        "circuitName": "Albert Park Grand Prix Circuit",
-        "Location": {"lat": -37.8497,  # cast from str
-                     "long": 144.968,
-                     "locality": "Melbourne",
-                     "country": "Australia"}
-    }, {
-        "circuitId": "bahrain",
-        "url": "https://...",
-        "circuitName": "Bahrain International Circuit",
-        "Location": {"lat": 26.0325,
-                     "long": 50.5106,
-                     "locality": "Sakhir",
-                     "country": "Bahrain"}
-    }]
+    expected = [
+        {
+            'season': int(2025),
+            'round': int(1),
+            'url': 'https://...',
+            'raceName': 'Australian Grand Prix',
+            'Circuit': {
+                'circuitId': 'albert_park',
+                'url': 'https://...',
+                'circuitName': 'Albert Park Grand Prix Circuit',
+                'Location': {
+                    'lat': float(-37.8497),
+                    'long': float(144.968),
+                    'locality': 'Melbourne',
+                    'country': 'Australia'
+                }
+            },
+            'date': datetime.datetime(2025, 3, 16, 0, 0),
+            'time': datetime.time(4, 0, tzinfo=datetime.timezone.utc),
+            'Results': [
+                {
+                    'number': int(4),
+                    'position': int(1),
+                    'positionText': '1',
+                    'points': float(25),
+                    'Driver': {
+                        'driverId': 'norris',
+                        'permanentNumber': int(4),
+                        'code': 'NOR',
+                        'url': 'http://...',
+                        'givenName': 'Lando',
+                        'familyName': 'Norris',
+                        'dateOfBirth': datetime.datetime(1999, 11, 13, 0, 0),
+                        'nationality': 'British'
+                    },
+                    'Constructor': {
+                        'constructorId': 'mclaren',
+                        'url': 'http://...',
+                        'name': 'McLaren',
+                        'nationality': 'British'
+                    },
+                    'grid': int(1),
+                    'laps': int(57),
+                    'status': 'Finished',
+                    'Time': {
+                        'millis': int(6126304),
+                        'time': datetime.timedelta(seconds=6126, microseconds=304000)
+                    },
+                    'FastestLap': {
+                        'rank': int(1),
+                        'lap': int(43),
+                        'Time': {
+                            'time': datetime.timedelta(seconds=82, microseconds=167000)
+                        }
+                    }
+                },
+            ]
+        },
+    ]
 
     result = ErgastRawResponse(query_result=data,
-                               category=API.Circuits,
+                               category=API.Races_RaceResults,
                                auto_cast=True,
                                # set invalid arguments for Mixin: not required
                                response_headers=None,


### PR DESCRIPTION
Loading an Ergast Raw Response with auto cast did not correctly parse subcategories when these were of type list. This meant that the content of these categories was not cast.

Example: On the race results endpoint, the main response objects and all objects in the Circuits object were cast correctly. All objects in the Results array weren't cast.