### PR TITLE
Fix: Apply forward fill to speed trap data

### DIFF
--- a/fastf1/_api.py
+++ b/fastf1/_api.py
@@ -239,6 +239,11 @@ def _extended_timing_data(path, response=None, livedata=None):
             stream_data[key].extend(drv_stream_data[key])
 
     laps_data = pd.DataFrame(laps_data)
+
+    # Forward fill missing speed trap values as they are omitted by the API when unchanged
+    speed_cols = ['SpeedI1', 'SpeedI2', 'SpeedFL', 'SpeedST']
+    laps_data[speed_cols] = laps_data.groupby('Driver')[speed_cols].ffill()
+
     stream_data = pd.DataFrame(stream_data)
 
     _align_laps(laps_data, stream_data)


### PR DESCRIPTION
Hi,

I've fixed the issue where speed trap data contained `NaN` values, causing gaps in visualization.

**Changes:**
- Applied `.ffill()` method to the speed trap column in _api.py to handle missing data points.

This ensures continuous lines in telemetry plots.

Closes #775