### PR TITLE
fix: loading telemetry after laps adds extra lap data (#839)

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1419,6 +1419,7 @@ class Session:
                 self._load_track_status_data(livedata=livedata)
                 self._load_laps_data(livedata=livedata)
                 self._add_first_lap_time_from_ergast()
+                self._fix_missing_laps_retired_on_track()
 
             if telemetry:
                 self._load_telemetry(livedata=livedata)
@@ -1437,7 +1438,6 @@ class Session:
                     "session."
                 )
 
-        self._fix_missing_laps_retired_on_track()
         self._set_laps_deleted_from_rcm()
         self._calculate_quali_like_session_results()
         self._calculate_race_like_session_results()


### PR DESCRIPTION
Issue #839: Loading telemetry data after loading lap data modifies the lap data (this doesn't happen if you load lap data and telemetry data at the same time).

## Changes
- Moved `self._fix_missing_laps_retired_on_track()` into the `if laps:` conditional in the `load()` function within `class Session`.

## Example
I verified the fix by running the example code provided in the original issue before and after the change. The code and the results are shown below:
```python3
import fastf1

fastf1.set_log_level("ERROR")

# 2019 Canadian GP - NOR retired on lap 9 with suspension damage
session = fastf1.get_session(2019, 7, 'R')

print("\n1. Load with laps=True, telemetry=True together:")
session.load(laps=True, telemetry=True)
nor_laps = session.laps[session.laps['Driver'] == 'NOR']
print(f"   NOR lap count: {len(nor_laps)}")

print("\n2. Fresh session - load laps first, then telemetry:")
session2 = fastf1.get_session(2019, 7, 'R')
session2.load(laps=True)
nor_laps_after_laps = session2.laps[session2.laps['Driver'] == 'NOR']
print(f"   After laps only - NOR lap count: {len(nor_laps_after_laps)}")

session2.load(laps=False, telemetry=True)
nor_laps_after_telemetry = session2.laps[session2.laps['Driver'] == 'NOR']
print(f"   After adding telemetry - NOR lap count: {len(nor_laps_after_telemetry)}")
```

### Output (before):
```
1. Load with laps=True, telemetry=True together:
   NOR lap count: 9

2. Fresh session - load laps first, then telemetry:
   After laps only - NOR lap count: 9
   After adding telemetry - NOR lap count: 10
```
### Output (after):
```
1. Load with laps=True, telemetry=True together:
   NOR lap count: 9

2. Fresh session - load laps first, then telemetry:
   After laps only - NOR lap count: 9
   After adding telemetry - NOR lap count: 9
```

## Testing
The existing pytest suit was ran before and after making the change, with no new failures resulting from it.