### PR TITLE
MNT: fastf1.events - fuzzy match improvements, better exceptions, removals

### DIFF
--- a/docs/api_reference/exceptions.rst
+++ b/docs/api_reference/exceptions.rst
@@ -19,7 +19,7 @@ Data Loading Exceptions
 .. autoclass:: fastf1.exceptions.DataNotLoadedError
     :show-inheritance:
 
-.. autoclass:: fastf1.exceptions.InvalidSessionError
+.. autoclass:: fastf1.exceptions.FuzzyMatchError
     :show-inheritance:
 
 .. autoclass:: fastf1.exceptions.NoLapDataError
@@ -46,3 +46,4 @@ Legacy Exceptions (deprecated)
 
 .. autoclass:: fastf1._api.SessionNotAvailableError
 
+.. autoclass:: fastf1.exceptions.InvalidSessionError

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -38,14 +38,20 @@ from fastf1.mvapi import (
 from fastf1.utils import to_timedelta
 
 
-# TODO: remove in v3.10
 def __getattr__(name):
+    # TODO: remove in v3.10
     if name in ("NoLapDataError",
-                "DataNotLoadedError",
-                "InvalidSessionError"):
+                "DataNotLoadedError"):
 
         warnings.warn(f"Accessing `{name}` via `{__name__}` is deprecated. "
                       f"Use `fastf1.exceptions` instead.")
+
+        return getattr(exceptions, name)
+
+    # TODO: remove in v3.11
+    elif name == "InvalidSessionError":
+        warnings.warn(f"`{name}` is deprecated and will be removed in a "
+                      f"future version.")
 
         return getattr(exceptions, name)
 

--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -215,7 +215,7 @@ def get_event(
             fuzzy search.
 
     Raises:
-        :class:`~fastf1.exceptions.FuzzyMatchError` when ``exact_match`` is
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
             ``False`` and not match with sufficient confidence is found.
 
         :class:`ValueError`: ``gp`` is a string, ``exact_match`` is ``False``
@@ -225,7 +225,7 @@ def get_event(
         :class:`ValueError`: ``gp`` is an integer and the round number
             is invalid.
 
-        :class:`KeyError` when ``exact_match`` is ``True`` and no exact
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact
             match exists.
     """
     schedule = get_event_schedule(year=year,

--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -51,6 +51,7 @@ def get_session(
         identifier: int | str | None = None,
         *,
         backend: Literal['fastf1', 'f1timing', 'ergast'] | None = None,
+        exact_match: bool = False
 ) -> Session:
     """Create a :class:`~fastf1.core.Session` object based on year, event name
     and session identifier.
@@ -111,6 +112,9 @@ def get_session(
 
             For seasons older than 2018 ``'ergast'`` is always used.
 
+        exact_match: Match precisely the query, or default to
+            fuzzy search.
+
     Raises:
         :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
             ``False`` and not match with sufficient confidence is found.
@@ -128,7 +132,7 @@ def get_session(
         :class:`KeyError`: ``exact_match`` is ``True`` and no exact
             match exists.
     """
-    event = get_event(year, gp, backend=backend)
+    event = get_event(year, gp, backend=backend, exact_match=exact_match)
     return event.get_session(identifier)
 
 
@@ -208,8 +212,7 @@ def get_event(
             For seasons older than 2018 ``'ergast'`` is always used.
 
         exact_match: Match precisely the query, or default to
-            fuzzy search. If no event is found with
-            ``exact_match=True``, the function will return None
+            fuzzy search.
 
     Raises:
         :class:`~fastf1.exceptions.FuzzyMatchError` when ``exact_match`` is
@@ -808,7 +811,7 @@ class EventSchedule(BaseDataFrame):
                 exact_match=True)``
                 will return the event for the British Grand Prix, whereas
                 ``.get_event_by_name("British", exact_match=True)``
-                will return ``None``
+                will raise a ``KeyError``
 
         Raises:
             :class:`~fastf1.exceptions.FuzzyMatchError` when ``exact_match``

--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -1,7 +1,6 @@
 import collections
 import datetime
 import json
-import warnings
 from typing import Literal
 
 import dateutil.parser
@@ -52,7 +51,6 @@ def get_session(
         identifier: int | str | None = None,
         *,
         backend: Literal['fastf1', 'f1timing', 'ergast'] | None = None,
-        force_ergast: bool = False,
 ) -> Session:
     """Create a :class:`~fastf1.core.Session` object based on year, event name
     and session identifier.
@@ -96,6 +94,7 @@ def get_session(
             see :ref:`event-session-identifier`
 
         backend: select a specific backend as data source, options:
+
             - ``'fastf1'``: FastF1's own backend, full support for 2018 to now
 
             - ``'f1timing'``: uses data from the F1 live timing API, sessions
@@ -112,10 +111,24 @@ def get_session(
 
             For seasons older than 2018 ``'ergast'`` is always used.
 
-        force_ergast: [Deprecated, use ``backend='ergast'``] Always use data
-            from the ergast database to create the event schedule
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
+            ``False`` and not match with sufficient confidence is found.
+
+        :class:`ValueError`: ``gp`` is a string, ``exact_match`` is ``False``
+            and the provided ``name`` is shorter than four characters after
+            common phrases like "Formula 1", "Grand Prix", etc. are removed.
+
+        :class:`ValueError`: ``gp`` is an integer and the round number
+            is invalid.
+
+        :class:`ValueError`: there exists no matching session for this event
+            or ``identifier`` is invalid
+
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact
+            match exists.
     """
-    event = get_event(year, gp, force_ergast=force_ergast, backend=backend)
+    event = get_event(year, gp, backend=backend)
     return event.get_session(identifier)
 
 
@@ -148,8 +161,6 @@ def get_testing_session(
             When no backend is specified, ``'fastf1'`` is used as a default and
             ``f1timing`` is used as a fallback in case the default
             is not available.
-
-    .. versionadded:: 2.2
     """
     event = get_testing_event(year, test_number, backend=backend)
     return event.get_session(session_number)
@@ -160,8 +171,6 @@ def get_event(
         gp: int | str,
         *,
         backend: Literal['fastf1', 'f1timing', 'ergast'] | None = None,
-        force_ergast: bool = False,
-        strict_search: bool = False,
         exact_match: bool = False
 ) -> "Event":
     """Create an :class:`~fastf1.events.Event` object for a specific
@@ -198,25 +207,31 @@ def get_event(
 
             For seasons older than 2018 ``'ergast'`` is always used.
 
-        force_ergast: [Deprecated, use ``backend='ergast'``] Always use data
-            from the ergast database to create the event schedule
-
-        strict_search: This argument is deprecated and planned for removal,
-            use the equivalent ``exact_match`` instead
-
         exact_match: Match precisely the query, or default to
             fuzzy search. If no event is found with
             ``exact_match=True``, the function will return None
 
-    .. versionadded:: 2.2
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError` when ``exact_match`` is
+            ``False`` and not match with sufficient confidence is found.
+
+        :class:`ValueError`: ``gp`` is a string, ``exact_match`` is ``False``
+            and the provided ``name`` is shorter than four characters after
+            common phrases like "Formula 1", "Grand Prix", etc. are removed.
+
+        :class:`ValueError`: ``gp`` is an integer and the round number
+            is invalid.
+
+        :class:`KeyError` when ``exact_match`` is ``True`` and no exact
+            match exists.
     """
-    schedule = get_event_schedule(year=year, include_testing=False,
-                                  force_ergast=force_ergast,
+    schedule = get_event_schedule(year=year,
+                                  include_testing=False,
                                   backend=backend)
 
     if isinstance(gp, str):
         event = schedule.get_event_by_name(
-            gp, strict_search=strict_search, exact_match=exact_match)
+            gp, exact_match=exact_match)
     else:
         event = schedule.get_event_by_round(gp)
 
@@ -246,8 +261,6 @@ def get_testing_event(
             When no backend is specified, ``'fastf1'`` is used as a default and
             ``f1timing`` is used as a fallback in case the default
             is not available.
-
-    .. versionadded:: 2.2
     """
     if backend == 'ergast':
         raise ValueError("The 'ergast' backend does not support "
@@ -267,7 +280,6 @@ def get_event_schedule(
         *,
         include_testing: bool = True,
         backend: Literal['fastf1', 'f1timing', 'ergast'] | None = None,
-        force_ergast: bool = False
 ) -> "EventSchedule":
     """Create an :class:`~fastf1.events.EventSchedule` object for a specific
     season.
@@ -295,18 +307,7 @@ def get_event_schedule(
             is not available.
 
             For seasons older than 2018 ``'ergast'`` is always used.
-
-        force_ergast: [Deprecated, use ``backend='ergast'``] Always use data
-            from the ergast database to create the event schedule
-
-    .. versionadded:: 2.2
-
     """
-    if force_ergast:
-        warnings.warn("Option ``force_ergast`` has been deprecated, use"
-                      "``backend='ergast'`` instead")
-        backend = 'ergast'
-
     _backends_named_order = {
         'fastf1': _get_schedule_ff1,
         'f1timing': _get_schedule_from_f1_timing,
@@ -339,7 +340,6 @@ def get_events_remaining(
         *,
         include_testing: bool = True,
         backend: Literal['fastf1', 'f1timing', 'ergast'] | None = None,
-        force_ergast: bool = False
 ) -> 'EventSchedule':
     """
     Create an :class:`~fastf1.events.EventSchedule` object for remaining
@@ -368,18 +368,14 @@ def get_events_remaining(
             is not available.
 
             For seasons older than 2018 ``'ergast'`` is always used.
-
-        force_ergast: [Deprecated, use ``backend='ergast'``] Always use data
-            from the ergast database to create the event schedule
-
-    .. versionadded:: 2.3
     """
     if dt is None:
         dt = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
 
     events = get_event_schedule(
-        dt.year, include_testing=include_testing,
-        force_ergast=force_ergast, backend=backend
+        dt.year,
+        include_testing=include_testing,
+        backend=backend
     )
 
     if not include_testing:
@@ -653,8 +649,6 @@ class EventSchedule(BaseDataFrame):
         year: Championship year
         **kwargs: passed on to :class:`pandas.DataFrame` superclass
             (except 'columns' which is unsupported for the event schedule)
-
-    .. versionadded:: 2.2
     """
 
     _COLUMNS = {
@@ -714,7 +708,7 @@ class EventSchedule(BaseDataFrame):
             raise ValueError(f"Invalid round: {round}")
         return self[mask].iloc[0]
 
-    def _strict_event_search(self, name: str):
+    def _strict_event_search(self, name: str) -> "Event":
         """
         Match Event Name exactly, ignoring case.
         """
@@ -725,16 +719,22 @@ class EventSchedule(BaseDataFrame):
                 if event['EventName'].lower() == query:
                     return self.loc[i]
         else:
-            return None
+            raise KeyError(f"No exact event name for '{name}'!")
 
     def _fuzzy_event_search(self, name: str) -> "Event":
 
         def _remove_common_words(event_name):
-            common_words = ["formula 1", str(self.year), "grand prix", "gp"]
+            common_words = [
+                "formula 1", "formula1", str(self.year), "grand prix", "gp"
+            ]
             event_name = event_name.casefold()
 
             for word in common_words:
                 event_name = event_name.replace(word, "")
+
+            event_name = event_name.strip().rstrip()
+            while "  " in event_name:
+                event_name = event_name.replace("  ", " ")
 
             return event_name
 
@@ -753,9 +753,19 @@ class EventSchedule(BaseDataFrame):
         user_input = name
         name = _remove_common_words(name)
 
+        if len(name) < 4:
+            raise ValueError(
+                f'Unique part of the event name is too short! "{user_input}" '
+                f'simplifies to "{name}" but must be >=4 letters. Use a more '
+                f'descriptive event name.'
+            )
+
         reference = [_matcher_strings(event) for _, event in self.iterrows()]
 
-        index, exact = fuzzy_matcher(name, reference)
+        index, exact = fuzzy_matcher(name, reference,
+                                     abs_confidence=0.5,
+                                     rel_confidence=0.1)
+
         event = self.iloc[index]
 
         if not exact:
@@ -768,7 +778,6 @@ class EventSchedule(BaseDataFrame):
             self,
             name: str,
             *,
-            strict_search: bool = False,
             exact_match: bool = False
     ) -> "Event":
         """Get an :class:`Event` by its name.
@@ -792,8 +801,7 @@ class EventSchedule(BaseDataFrame):
                 ``.get_event_by_name("british")`` and
                 ``.get_event_by_name("silverstone")`` will both return the
                 event for the British Grand Prix.
-            strict_search: This argument is deprecated and planned for removal.
-                Use the equivalent ``exact_match`` instead
+
             exact_match: Search only for exact query matches
                 instead of using fuzzy search. For example,
                 ``.get_event_by_name("British Grand Prix",
@@ -801,12 +809,20 @@ class EventSchedule(BaseDataFrame):
                 will return the event for the British Grand Prix, whereas
                 ``.get_event_by_name("British", exact_match=True)``
                 will return ``None``
+
+        Raises:
+            :class:`~fastf1.exceptions.FuzzyMatchError` when ``exact_match``
+                is ``False`` and not match with sufficient confidence is
+                found.
+
+            :class:`ValueError` when ``exact_match`` is ``False`` and the
+                provided ``name`` is shorter than four characters after common
+                phrases like "Formula 1", "Grand Prix", etc. are removed.
+
+            :class:`KeyError` when ``exact_match`` is ``True`` and no exact
+                match exists.
         """
-        if strict_search:
-            warnings.warn(("strict_search is deprecated and planned for "
-                           "removal, use the equivalent exact_match instead"),
-                          FutureWarning)
-        if strict_search or exact_match:
+        if exact_match:
             return self._strict_event_search(name)
         else:
             return self._fuzzy_event_search(name)
@@ -934,7 +950,6 @@ class Event(BaseSeries):
         Args:
             identifier: session name, abbreviation or number,
                 see :ref:`event-session-identifier`
-
 
         Raises:
             ValueError: No matching session or invalid identifier

--- a/fastf1/exceptions.py
+++ b/fastf1/exceptions.py
@@ -1,3 +1,4 @@
+import warnings
 
 
 # Exceptions Structure and Handling in FastF1
@@ -24,6 +25,16 @@
 # through the catch-all error handling.
 
 
+def __getattr__(name):
+    # TODO: remove in v3.11
+    if name == "InvalidSessionError":
+        warnings.warn(f"`{name}` is deprecated and will be removed in a "
+                      f"future version.")
+        return _InvalidSessionError
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 # ### Default FastF1 Exceptions ###
 
 class DataNotLoadedError(Exception):
@@ -45,19 +56,6 @@ class ErgastJsonError(ErgastError):
 class ErgastInvalidRequestError(ErgastError):
     """The server rejected the request because it was invalid."""
     pass
-
-
-class InvalidSessionError(Exception):
-    """Raised if no session for the specified event name, type, and year
-    can be found.
-
-    .. deprecated:: v3.9.0
-
-        This exception is unused and will be removed in a future release.
-    """
-
-    def __init__(self, *args):
-        super().__init__("No matching session can be found.")
 
 
 class NoLapDataError(Exception):
@@ -92,3 +90,21 @@ class FastF1CriticalError(RuntimeError):
 class RateLimitExceededError(FastF1CriticalError):
     """Raised if a hard rate limit is exceeded for any API."""
     pass
+
+
+# ### Deprecated Exceptions ###
+
+# TODO: remove in v3.11
+InvalidSessionError: Exception
+"""Raised if no session for the specified event name, type, and year
+can be found.
+
+.. deprecated:: v3.9.0
+
+    This exception is unused and will be removed in a future release.
+"""
+
+
+class _InvalidSessionError(Exception):
+    def __init__(self, *args):
+        super().__init__("No matching session can be found.")

--- a/fastf1/exceptions.py
+++ b/fastf1/exceptions.py
@@ -49,7 +49,12 @@ class ErgastInvalidRequestError(ErgastError):
 
 class InvalidSessionError(Exception):
     """Raised if no session for the specified event name, type, and year
-    can be found."""
+    can be found.
+
+    .. deprecated:: v3.9.0
+
+        This exception is unused and will be removed in a future release.
+    """
 
     def __init__(self, *args):
         super().__init__("No matching session can be found.")
@@ -63,6 +68,13 @@ class NoLapDataError(Exception):
     def __init__(self, *args):
         super().__init__("Failed to load session because the API did not "
                          "provide any usable data.")
+
+
+class FuzzyMatchError(ValueError):
+    """
+    Raised if no fuzzy match could be found with sufficient confidence.
+    """
+    pass
 
 
 # ### Critical FastF1 Exceptions ###

--- a/fastf1/internals/fuzzy.py
+++ b/fastf1/internals/fuzzy.py
@@ -2,6 +2,8 @@ import warnings
 
 import numpy as np
 
+from fastf1.exceptions import FuzzyMatchError
+
 
 with warnings.catch_warnings():
     warnings.filterwarnings(
@@ -17,7 +19,7 @@ def fuzzy_matcher(
         reference: list[list[str]],
         abs_confidence: float = 0.0,
         rel_confidence: float = 0.0
-) -> (int, bool):
+) -> tuple[int, bool]:
     """
     Match a query string to a reference list of lists of strings using fuzzy
     string matching.
@@ -51,9 +53,8 @@ def fuzzy_matcher(
             raised.
 
     Returns:
-        (int, bool): Index of the best matching element in the
-            reference (outer) list and a boolean indicating if the match is
-            accurate or not.
+        Index of the best matching element in the reference (outer) list and
+        a boolean indicating if the match is accurate or not.
 
     """
     # Preprocess the query and reference strings
@@ -104,21 +105,23 @@ def fuzzy_matcher(
         mask = ((np.vectorize(count_dict.get)(reference) > 1)
                 & (ratios == max_ratio))
         ratios[mask] = 0
+        # update the max row ratios
+        max_row_ratios = np.max(ratios, axis=1)
 
     # get the index of the row that contains the maximum ratio
     max_index = np.argmax(ratios) // ratios.shape[1]
 
     # optional confidence checks
     if abs_confidence and (max_ratio < (abs_confidence * 100)):
-        raise KeyError(f"Found no match for '{query}' with sufficient "
-                       f"absolute confidence")
+        raise FuzzyMatchError(f"Found no match for '{query}' with sufficient "
+                              f"absolute confidence")
 
-    if rel_confidence and (max_ratio / np.partition(ratios.flatten(), -2)[-2]
+    if rel_confidence and (max_ratio / np.partition(max_row_ratios, -2)[-2]
                            < (1 + rel_confidence)):
         # max ratio divided by second-largest ratio is less
         # than 1 + rel_confidence
-        raise KeyError(f"Found no match for '{query}' with sufficient "
-                       f"relative confidence")
+        raise FuzzyMatchError(f"Found no match for '{query}' with sufficient "
+                              f"relative confidence")
 
     # return index as inaccurate match
     return max_index, False

--- a/fastf1/plotting/_interface.py
+++ b/fastf1/plotting/_interface.py
@@ -221,6 +221,14 @@ def get_team_name(
         short: if True, a shortened version of the team name will be returned
         exact_match: match the identifier exactly (case-insensitive, special
             characters are converted to their nearest ASCII equivalent)
+
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
+            ``False`` and the identifier could not be matched with sufficient
+            confidence.
+
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact match for
+            the identifier exists.
     """
     team = _get_team(identifier, session, exact_match=exact_match)
 
@@ -251,6 +259,14 @@ def get_team_name_by_driver(
         short: if True, a shortened version of the team name will be returned
         exact_match: match the identifier exactly (case-insensitive, special
             characters are converted to their nearest ASCII equivalent)
+
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
+            ``False`` and the identifier could not be matched with sufficient
+            confidence.
+
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact match for
+            the identifier exists.
     """
     driver = _get_driver(identifier, session, exact_match=exact_match)
     team = driver.team
@@ -285,6 +301,14 @@ def get_team_color(
 
     Returns:
         A hexadecimal RGB color code
+
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
+            ``False`` and the identifier could not be matched with sufficient
+            confidence.
+
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact match for
+            the identifier exists.
     """
     return _get_team_color(identifier, session,
                            colormap=colormap,
@@ -303,6 +327,14 @@ def get_driver_name(
         session: the session for which the data should be obtained
         exact_match: match the identifier exactly (case-insensitive, special
             characters are converted to their nearest ASCII equivalent)
+
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
+            ``False`` and the identifier could not be matched with sufficient
+            confidence.
+
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact match for
+            the identifier exists.
     """
     driver = _get_driver(identifier, session, exact_match=exact_match)
     return driver.name
@@ -325,6 +357,14 @@ def get_driver_abbreviation(
         session: the session for which the data should be obtained
         exact_match: match the identifier exactly (case-insensitive, special
             characters are converted to their nearest ASCII equivalent)
+
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
+            ``False`` and the identifier could not be matched with sufficient
+            confidence.
+
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact match for
+            the identifier exists.
     """
     driver = _get_driver(identifier, session, exact_match=exact_match)
     return driver.abbreviation
@@ -342,6 +382,14 @@ def get_driver_names_by_team(
         session: the session for which the data should be obtained
         exact_match: match the identifier exactly (case-insensitive, special
             characters are converted to their nearest ASCII equivalent)
+
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
+            ``False`` and the identifier could not be matched with sufficient
+            confidence.
+
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact match for
+            the identifier exists.
     """
     team = _get_team(identifier, session, exact_match=exact_match)
     return [driver.name for driver in team.drivers]
@@ -359,6 +407,14 @@ def get_driver_abbreviations_by_team(
         session: the session for which the data should be obtained
         exact_match: match the identifier exactly (case-insensitive, special
             characters are converted to their nearest ASCII equivalent)
+
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
+            ``False`` and the identifier could not be matched with sufficient
+            confidence.
+
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact match for
+            the identifier exists.
     """
     team = _get_team(identifier, session, exact_match=exact_match)
     return [driver.abbreviation for driver in team.drivers]
@@ -396,6 +452,13 @@ def get_driver_color(
     Returns:
         A hexadecimal RGB color code
 
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
+            ``False`` and the identifier could not be matched with sufficient
+            confidence.
+
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact match for
+            the identifier exists.
     """
     return _get_driver_color(identifier, session, colormap=colormap,
                              exact_match=exact_match)
@@ -552,6 +615,13 @@ def get_driver_style(
     Returns: a dictionary of plot style arguments that can be directly passed
         to a matplotlib plot function using the ``**`` expansion operator
 
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: ``exact_match`` is
+            ``False`` and the identifier could not be matched with sufficient
+            confidence.
+
+        :class:`KeyError`: ``exact_match`` is ``True`` and no exact match for
+            the identifier exists.
 
     .. minigallery:: fastf1.plotting.get_driver_style
         :add-heading:
@@ -766,8 +836,12 @@ def add_sorted_driver_legend(
         *args: Matplotlib legend args
         **kwargs: Matplotlib legend kwargs
 
-     Returns:
+    Returns:
         ``matplotlib.legend.Legend``
+
+    Raises:
+        :class:`~fastf1.exceptions.FuzzyMatchError`: The labels in the legend
+            could not be matched to known drivers with sufficient confidence.
 
     .. minigallery:: fastf1.plotting.add_sorted_driver_legend
         :add-heading:

--- a/fastf1/tests/test_events.py
+++ b/fastf1/tests/test_events.py
@@ -173,13 +173,16 @@ def test_event_fuzzy_search():
     assert schedule.get_event_by_name(
         "Imola").EventName == "Emilia Romagna Grand Prix"
     assert schedule.get_event_by_name(
-        "USGP").EventName == "United States Grand Prix"
-    assert schedule.get_event_by_name(
-        "US GP").EventName == "United States Grand Prix"
-    assert schedule.get_event_by_name(
         "Mexican GP").EventName == "Mexico City Grand Prix"
     assert schedule.get_event_by_name(
         "Brazilian GP").EventName == "São Paulo Grand Prix"
+
+
+def test_event_fuzzy_unique_too_short():
+    schedule = fastf1.get_event_schedule(2024)
+
+    with pytest.raises(ValueError, match='too short'):
+        schedule.get_event_by_name("US")
 
 
 @pytest.mark.parametrize(

--- a/fastf1/tests/test_events.py
+++ b/fastf1/tests/test_events.py
@@ -5,6 +5,7 @@ import pytest
 
 import fastf1.core
 import fastf1.events
+from fastf1.exceptions import FuzzyMatchError
 
 
 @pytest.mark.parametrize('backend', ['fastf1', 'f1timing', 'ergast'])
@@ -183,6 +184,30 @@ def test_event_fuzzy_unique_too_short():
 
     with pytest.raises(ValueError, match='too short'):
         schedule.get_event_by_name("US")
+
+
+def test_get_session_exceptions():
+    # fuzzy match confidence is too low
+    with pytest.raises(FuzzyMatchError, match="confidence"):
+        fastf1.get_session(2023, "This GP does not exist", "R")
+
+    # the unique part of the provided event name is too short
+    with pytest.raises(ValueError, match="too short"):
+        fastf1.get_session(2023, "Spa", "R")
+
+    # invalid round number
+    with pytest.raises(ValueError, match="Invalid round"):
+        fastf1.get_session(2023, 35, "R")
+
+    # invalid session identifier
+    with pytest.raises(ValueError, match="Invalid session"):
+        fastf1.get_session(2023, 10, 6)
+    with pytest.raises(ValueError, match="Invalid session"):
+        fastf1.get_session(2023, 10, "RR")
+
+    # no exact match
+    with pytest.raises(KeyError):
+        fastf1.get_session(2023, "Alaskan Grand Prix", "R", exact_match=True)
 
 
 @pytest.mark.parametrize(

--- a/fastf1/tests/test_exceptions.py
+++ b/fastf1/tests/test_exceptions.py
@@ -33,10 +33,6 @@ def test_legacy_import_warns():
 
     with pytest.warns(UserWarning,
                       match="Accessing .* via .* is deprecated"):
-        from fastf1.core import InvalidSessionError
-
-    with pytest.warns(UserWarning,
-                      match="Accessing .* via .* is deprecated"):
         from fastf1.core import NoLapDataError
 
     with pytest.warns(UserWarning,
@@ -51,7 +47,6 @@ def test_legacy_import_warns():
         ("fastf1.ergast.interface", "ErgastJsonError"),
         ("fastf1.ergast.interface", "ErgastInvalidRequestError"),
         ("fastf1.core", "DataNotLoadedError"),
-        ("fastf1.core", "InvalidSessionError"),
         ("fastf1.core", "NoLapDataError"),
         ("fastf1", "RateLimitExceededError"),
     ]
@@ -60,6 +55,30 @@ def test_legacy_access_warns(module, name):
     m = importlib.import_module(module)
     with pytest.warns(UserWarning,
                       match="Accessing .* via .* is deprecated"):
+        getattr(m, name)
+
+
+def test_deprecated_import_warns():
+    with pytest.warns(UserWarning,
+                      match="is deprecated and will be removed"):
+        from fastf1.exceptions import InvalidSessionError
+
+    with pytest.warns(UserWarning,
+                      match="is deprecated and will be removed"):
+        from fastf1.core import InvalidSessionError
+
+
+@pytest.mark.parametrize(
+    "module, name",
+    [
+        ("fastf1.exceptions", "InvalidSessionError"),
+        ("fastf1.core", "InvalidSessionError"),
+    ]
+)
+def test_deprecated_access_warns(module, name):
+    m = importlib.import_module(module)
+    with pytest.warns(UserWarning,
+                      match="is deprecated and will be removed"):
         getattr(m, name)
 
 

--- a/fastf1/tests/test_fuzzy.py
+++ b/fastf1/tests/test_fuzzy.py
@@ -1,0 +1,93 @@
+import pytest
+
+from fastf1.exceptions import FuzzyMatchError
+from fastf1.internals.fuzzy import fuzzy_matcher
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        # accurate matches
+        ["Australia", (0, True)],
+        ["China", (1, True)],
+        ["Spielberg", (2, True)],
+        # non-accurate matches
+        ["Australian GP", (0, False)],
+        ["Shanghai Circuit", (1, False)],
+        ["Spliebreg", (2, False)],
+    ]
+)
+def test_fuzzy_matcher(query, expected):
+    reference = [
+        ["Australia", "Melbourne", "Albert Park Circuit"],
+        ["China", "Shanghai", "Shanghai International Circuit"],
+        ["Austria", "Spielberg", "Red Bull Ring"]
+    ]
+
+    result = fuzzy_matcher(query, reference)
+
+    assert result == expected
+
+
+def test_fuzzy_matcher_rel_confidence_too_low():
+    reference = [
+        ["Australia", "Melbourne", "Albert Park Circuit"],
+        ["China", "Shanghai", "Shanghai International Circuit"],
+        ["Austria", "Spielberg", "Red Bull Ring"]
+    ]
+
+    # "Australa" is a close match to "Austria" and "Australia", therefore,
+    # the relative confidence of the match is low.
+
+    assert fuzzy_matcher("Australa", reference) == (0, False)
+
+    with pytest.raises(FuzzyMatchError, match="relative confidence"):
+        fuzzy_matcher("Australa", reference, rel_confidence=0.3)
+
+
+def test_fuzzy_matcher_abs_confidence_too_low():
+    reference = [
+        ["Australia", "Melbourne", "Albert Park Circuit"],
+        ["China", "Shanghai", "Shanghai International Circuit"],
+        ["Austria", "Spielberg", "Red Bull Ring"]
+    ]
+
+    # "Österreich" is not a good match for anything, therefore, the absolute
+    # confidence of the match is low.
+    with pytest.raises(FuzzyMatchError, match="absolute confidence"):
+        fuzzy_matcher("Österreich", reference, abs_confidence=0.7)
+
+
+def test_accurate_match_ignores_confidence():
+    reference = [
+        ["Australia", "Melbourne", "Albert Park Circuit"],
+        ["China", "Shanghai", "Shanghai International Circuit"],
+        ["Austria", "Spielberg", "Red Bull Ring"]
+    ]
+
+    # "Red Bull" is an accurate substring match for "Red Bull Ring", but
+    # it does not have 99% absolute and relative confidence when fuzzy.
+    # Confidence should be ignored for accurate substring matches if there
+    # is only one accurate substring match.
+
+    assert fuzzy_matcher("Red Bull", reference) == (2, True)
+    assert fuzzy_matcher(
+        "Red Bull", reference, abs_confidence=0.99) == (2, True)
+    assert fuzzy_matcher(
+        "Red Bull", reference, rel_confidence=0.99) == (2, True)
+
+
+def test_relative_confidence_only_between_elements():
+    reference = [
+        ["Australia", "Australia"],
+        ["China", "China"],
+    ]
+
+    # Prevent a bug where relative confidence was calculated against all
+    # feature strings. Since feature strings in the same row describe the same
+    # element, this makes no sense. Relative confidenc must only be calculated
+    # against the maximum fuzzy match ratio of each row of the reference.
+
+    assert fuzzy_matcher("Australian GP", reference) == (0, False)
+    assert fuzzy_matcher(
+        "Australian GP", reference, rel_confidence=0.3) == (0, False)

--- a/fastf1/tests/test_plotting.py
+++ b/fastf1/tests/test_plotting.py
@@ -3,6 +3,7 @@ import pytest
 
 import fastf1
 import fastf1.plotting
+from fastf1.exceptions import FuzzyMatchError
 from fastf1.plotting._backend import Constants
 from fastf1.plotting._base import CompoundTypes
 from fastf1.testing import run_in_subprocess
@@ -85,10 +86,10 @@ def test_internal_get_team(identifier, expected, can_match_exact, use_exact):
 def test_fuzzy_driver_team_key_error():
     session = fastf1.get_session(2023, 10, 'R')
 
-    with pytest.raises(KeyError):
+    with pytest.raises(FuzzyMatchError):
         _ = fastf1.plotting._interface._get_team('andretti', session)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(FuzzyMatchError):
         _ = fastf1.plotting._interface._get_driver('toto wolf', session)
 
 


### PR DESCRIPTION
- address https://github.com/theOehrly/Fast-F1/issues/851#issuecomment-3887102727
- perform long overdue removals from deprecation in v2.x
- minor typing fixes
- improved errors when using ``get_session`` and ``get_event``, removing ambiguity about exceptions and return types
- add custom fuzzy match exception
-  deprecate previously unused ``InvalidSessionError``

ToDo
- [x] proofread documentation changes, ensure full documentation
- [x] add tests for error scenarios to verify exceptions
- [x] add deprecation warning on import and access of  ``InvalidSessionError``
- [x] add test for bug in fuzzy matcher by using rel_confidence with duplicated feature strings

Notes
https://github.com/theOehrly/Fast-F1/issues/851#issuecomment-3887102727 was caused by multiple problems:
- ``rel_confidence`` and ``abs_confidence`` were unused for event name matching
- Setting non-zero relative confidence requirements exposed a bug in the fuzzy matcher, where relative confidence was calculated against the whole array of ratios. Since ratios in the same row refer to the ratios of the various feature strings for **the same element**, this is not a useful comparison.  Only the maximum of each row should be compared to the maxima of other rows so that the comparison is between elements.