### PR TITLE
FIX: correct timestamps of bunched up tyre data

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1496,8 +1496,14 @@ class Session:
             if d2.shape[0] != len(d2['Stint'].unique()):
                 # tyre info includes correction messages that need to be
                 # applied before continuing
-                pit_in_times = list(d1['PitInTime'].dropna().unique())
-                d2 = self.__fix_tyre_info(d2, pit_in_times)
+
+                # Find all laps where a driver went into the pits. Their end
+                # times mark the end of each stint.
+                stint_split_times = d1.loc[
+                    ~pd.isnull(d1["PitInTime"]), "Time"
+                ].to_list()
+
+                d2 = self.__fix_tyre_info(d2, stint_split_times)
 
             is_generated = False
             if not len(d1):
@@ -2136,23 +2142,50 @@ class Session:
             self._session_start_time = None
         self._session_status = pd.DataFrame(session_status)
 
-    def __fix_tyre_info(self, df: pd.DataFrame, pit_in_times: list):
-        # ### Part 1: detect and fix incorrectly incremented stint counter
+    def __fix_tyre_info(self, df: pd.DataFrame, stint_split_times: list):
+        did_pit_in_session = bool(stint_split_times)
+
+        # add an artificial start and end time to the stint split times so
+        # that two subsequent timestamps always bracket a stint
+        stint_brackets = [
+            pd.Timedelta(0), *stint_split_times, pd.Timedelta(days=1)
+        ]
+
+        # ### Problem 1: Detect bunched up tyre data messages at the start
+        #                of a session and adjust their timestamps.
+        # ref: GH#863
+        if (did_pit_in_session
+                and not (df['Time'] < self.session_start_time).any()):
+            # TODO: assumption may only be true for races?
+            # No tyre data messages were registered before the start of the
+            # session. This points towards a delay in the transmission of the
+            # data. Check if messages for multiple stints are bunched up with
+            # the same timestamp at the beginning of the data stream.
+
+            first_ts = df['Time'].iloc[0]
+            delayed_stints = df.loc[df['Time'] == first_ts, 'Stint'].unique()
+
+            # If there are any delayed stints, set the timestamps of the
+            # message(s) for these stints to the start of the corresponding
+            # stint + 1 ms so that they are just within the stint bracket.
+            for n in delayed_stints:
+                df.loc[
+                    (df['Stint'] == n) & (df['Time'] == first_ts), 'Time'
+                ] = stint_brackets[n] + pd.Timedelta(milliseconds=1)
+
+        # ### Problem 2: detect and fix incorrectly incremented stint counter
         # ref: GH#715, GH#742
 
         # Pad pit in times with zero and a sufficiently far away value
         # such that two subsequent values in the list always bracket one
         # "stint". (The source data considers each drive through the pit as the
         # beginning of a new stint, independent of tyres being changed)
-        pit_in_times = [
-            pd.Timedelta(0), *pit_in_times, pd.Timedelta(days=1)
-        ]
 
         stint = 0  # stints are counted starting at zero in the source data
         fixed_stint_errors = False
-        for i in range(len(pit_in_times) - 1):
-            t_start = pit_in_times[i]
-            t_end = pit_in_times[i + 1]
+        for i in range(len(stint_brackets) - 1):
+            t_start = stint_brackets[i]
+            t_end = stint_brackets[i + 1]
 
             # Check if for any tyre data message in the current stint, the
             # stint counter is higher than the current stint. This would be

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -2152,15 +2152,17 @@ class Session:
         ]
 
         # ### Problem 1: Detect bunched up tyre data messages at the start
-        #                of a session and adjust their timestamps.
+        #                of a race session and adjust their timestamps.
         # ref: GH#863
-        if (did_pit_in_session
+        if (self.name in self._RACE_LIKE_SESSIONS
+                and did_pit_in_session
                 and not (df['Time'] < self.session_start_time).any()):
-            # TODO: assumption may only be true for races?
             # No tyre data messages were registered before the start of the
             # session. This points towards a delay in the transmission of the
             # data. Check if messages for multiple stints are bunched up with
             # the same timestamp at the beginning of the data stream.
+            # In non-race sessions, this should be ignored since drivers
+            # frequently only leave the pits after the session has started.
 
             first_ts = df['Time'].iloc[0]
             delayed_stints = df.loc[df['Time'] == first_ts, 'Stint'].unique()

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -2158,6 +2158,7 @@ class Session:
         # ref: GH#863
         if (self.name in self._RACE_LIKE_SESSIONS
                 and did_pit_in_session
+                and (self.session_start_time is not None)
                 and not (df['Time'] < self.session_start_time).any()):
             # No tyre data messages were registered before the start of the
             # session. This points towards a delay in the transmission of the

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -2145,8 +2145,10 @@ class Session:
     def __fix_tyre_info(self, df: pd.DataFrame, stint_split_times: list):
         did_pit_in_session = bool(stint_split_times)
 
-        # add an artificial start and end time to the stint split times so
-        # that two subsequent timestamps always bracket a stint
+        # Add an artificial start and end time to the stint split times so
+        # that two subsequent timestamps always bracket a stint.
+        # (The source data considers each drive through the pit lane as the
+        # beginning of a new stint, independent of tyres being changed)
         stint_brackets = [
             pd.Timedelta(0), *stint_split_times, pd.Timedelta(days=1)
         ]
@@ -2165,23 +2167,22 @@ class Session:
             # frequently only leave the pits after the session has started.
 
             first_ts = df['Time'].iloc[0]
-            delayed_stints = df.loc[df['Time'] == first_ts, 'Stint'].unique()
+            stints_at_first_ts = df.loc[
+                df['Time'] == first_ts, 'Stint'].unique()
 
-            # If there are any delayed stints, set the timestamps of the
-            # message(s) for these stints to the start of the corresponding
-            # stint + 1 ms so that they are just within the stint bracket.
-            for n in delayed_stints:
-                df.loc[
-                    (df['Stint'] == n) & (df['Time'] == first_ts), 'Time'
-                ] = stint_brackets[n] + pd.Timedelta(milliseconds=1)
+            # corrections are necessary if multiple stints are bunched up at
+            # the same first timestamp
+            if len(stints_at_first_ts) > 1:
+                # If there are any delayed stints, set the timestamps of the
+                # messages for these stints to the start of the corresponding
+                # stint + 1 ms so that they are just within the stint bracket.
+                for n in stints_at_first_ts:
+                    df.loc[
+                        (df['Stint'] == n) & (df['Time'] == first_ts), 'Time'
+                    ] = stint_brackets[n] + pd.Timedelta(milliseconds=1)
 
         # ### Problem 2: detect and fix incorrectly incremented stint counter
         # ref: GH#715, GH#742
-
-        # Pad pit in times with zero and a sufficiently far away value
-        # such that two subsequent values in the list always bracket one
-        # "stint". (The source data considers each drive through the pit as the
-        # beginning of a new stint, independent of tyres being changed)
 
         stint = 0  # stints are counted starting at zero in the source data
         fixed_stint_errors = False

--- a/fastf1/tests/test_input_data_handling.py
+++ b/fastf1/tests/test_input_data_handling.py
@@ -313,3 +313,20 @@ def test_tyre_data_incorrect_stint_counter(year, round_, session, drv, stints):
                 .pick_laps(range(start, end + 1))['Compound']
                 == compound
         ).all()
+
+
+@pytest.mark.f1telapi
+def test_compounds_correct_after_delayed_tyre_data():
+    # Tyre data was delayed and messages were bunched up with equivalent
+    # timestamp after the start of the session. This requires special case
+    # handling to ensure that the tyre data is still correctly assigned to
+    # the correct laps. (GH#863)
+
+    session = fastf1.get_session(2018, 'Azerbaijan', 'R')
+    session.load(telemetry=True)
+
+    compounds = (session.laps.pick_drivers('ALO')['Compound']
+                 .value_counts().to_dict())
+
+    # In case of incorrect handling, the supersoft stint would be missing.
+    assert compounds == {"SOFT": 39, "ULTRASOFT": 11, "SUPERSOFT": 1}

--- a/fastf1/tests/test_input_data_handling.py
+++ b/fastf1/tests/test_input_data_handling.py
@@ -323,7 +323,7 @@ def test_compounds_correct_after_delayed_tyre_data():
     # the correct laps. (GH#863)
 
     session = fastf1.get_session(2018, 'Azerbaijan', 'R')
-    session.load(telemetry=True)
+    session.load(telemetry=False, weather=False)
 
     compounds = (session.laps.pick_drivers('ALO')['Compound']
                  .value_counts().to_dict())


### PR DESCRIPTION
### PR summary

Detects when tyre data was delayed at the start of a session and all bunched up messages then have the same timestamp. In those cases, the timestamps are corrected so that they line up with their corresponding stints. This fixes issues with missing tyre data in some sessions.

Closes #863

##### ToDo

- ~~include proposed refactoring of tyre data parser from #872~~ implemented separately in #903
- ~~test against other sessions to ensure this breaks nothing~~
- ~~assumptions made may only hold for race-like sessions:  test and evaluate~~

#### AI Disclosure
No AI tools used
