### PR TITLE
Update ruff pre-commit hook and fail CI on warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
           # does not turn into errors (e.g. invalid noqa directives)
           ruff check . 2>&1 | tee /tmp/ruff_output.txt
           if grep -qi "warning" /tmp/ruff_output.txt; then
-            echo "::error::ruff emitted warnings (see above)"
+            echo "error: ruff emitted warnings (see above)"
             exit 1
           fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,8 +107,14 @@ jobs:
 
       - name: Run tests
         run: |
-          # ruff with default config
-          ruff check .
+          # ruff check with default config
+          # pipe stderr through grep to catch warnings that ruff
+          # does not turn into errors (e.g. invalid noqa directives)
+          ruff check . 2>&1 | tee /tmp/ruff_output.txt
+          if grep -qi "warning" /tmp/ruff_output.txt; then
+            echo "::error::ruff emitted warnings (see above)"
+            exit 1
+          fi
 
 
   run-isort-test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,8 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.12.7
+    rev: v0.15.8
     hooks:
-      # Run the linter.
-      - id: ruff
+      - id: ruff-check
 
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1594,7 +1594,7 @@ class Session:
         if df is None:
             raise exceptions.NoLapDataError
 
-        laps = df.reset_index(drop=True)  # noqa: F821
+        laps = df.reset_index(drop=True)
 
         # rename some columns
         laps.rename(columns={'Driver': 'DriverNumber',

--- a/fastf1/plotting/__init__.py
+++ b/fastf1/plotting/__init__.py
@@ -20,7 +20,7 @@ from fastf1.plotting._interface import (  # noqa: F401
     override_team_constants,
     set_default_colormap
 )
-from fastf1.plotting._plotting import setup_mpl  # noqa: F401
+from fastf1.plotting._plotting import setup_mpl
 
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ select = [
     "RET",
     "A",
     "PERF",
+    "RUF100",
 ]
 
 ignore = [


### PR DESCRIPTION
### PR summary

Fixes #878

Updated the ruff pre-commit hook from v0.12.7 to v0.15.8 and switched from the legacy `ruff` hook id to `ruff-check`.

For the CI action, ruff doesn't have a native flag to turn warnings into errors (astral-sh/ruff#8157), so the step now pipes output through grep and fails the job if any warnings show up.

Removed 2 stale noqa directives that ruff no longer needs:
- `# noqa: F821` in `core.py` (variable isn't undefined anymore)
- `# noqa: F401` in `plotting/__init__.py` (ruff now recognizes `__all__` re-exports)

Also added `RUF100` to the lint config so unused noqa directives get caught going forward.

#### AI Disclosure

AI tools were used to help locate the stale noqa directives and draft the CI grep step. All changes were reviewed and tested locally by me.