### PR TITLE
FIX: use jsDelivr CDN for schedule fetching to avoid GitHub raw API r…

### DIFF
--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -41,8 +41,8 @@ _SESSION_TYPE_ABBREVIATIONS = {
 }
 
 _SCHEDULE_BASE_URL = (
-    "https://raw.githubusercontent.com/"
-    "theOehrly/f1schedule/master/"
+    "https://cdn.jsdelivr.net/gh/"
+    "theOehrly/f1schedule@master/"
 )
 _HEADERS = {'User-Agent': f'FastF1/{__version_short__}'}
 

--- a/fastf1/tests/test_cache.py
+++ b/fastf1/tests/test_cache.py
@@ -43,7 +43,7 @@ def _test_cache_used_and_clear(tmpdir):
         with open('fastf1/testing/reference_data/'
                   'schedule_2020.json', 'rb') as fobj:
             content = fobj.read()
-        mocker.get('https://raw.githubusercontent.com/theOehrly/f1schedule/'
+        mocker.get('https://cdn.jsdelivr.net/gh/theOehrly/f1schedule@'
                    'master/schedule_2020.json',
                    content=content, status_code=200)
 


### PR DESCRIPTION
I’m getting rate limited by github because of raw.githubusercontent.com to fetch the schedule. This PR replaces it with the jsdelivr cdn which should eliminate the rate limiting issues.