### PR TITLE
FIX: invalid first lap added for DNS drivers that have tyre data

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1493,6 +1493,15 @@ class Session:
 
             is_generated = False
             if not len(d1):
+
+                if ((r := getattr(self, '_results', None)) is not None
+                        and (r.loc[driver, 'ClassifiedPosition'] == 'W')):
+                    # If a driver withdrew from the race before the start,
+                    # there will be no lap data.
+                    # Determining this reliably requires result data which
+                    # is not always available.
+                    continue
+
                 if self.name in self._RACE_LIKE_SESSIONS and len(d2):
                     # add data for drivers who crashed on the very first lap
                     # as a downside, this potentially adds a nonexistent lap

--- a/fastf1/tests/test_core.py
+++ b/fastf1/tests/test_core.py
@@ -59,10 +59,9 @@ def test_lap_data_loading_position_calculation_first_lap_retired():
 
     ref = {'Driver': ['VER', 'PIA', 'NOR', 'HAM', 'GAS', 'ALO', 'SAI', 'ANT',
                       'ALB', 'TSU', 'HUL', 'STR', 'OCO', 'RUS', 'LEC', 'HAD',
-                      'BOR', 'BEA', 'LAW', 'COL'],
+                      'BOR', 'BEA', 'LAW'],
            'Position': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0,
-                        12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, float('nan'),
-                        float('nan')]}
+                        12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, float('nan')]}
 
     ref_pos = pd.DataFrame(ref)
     pd.testing.assert_frame_equal(first_lap_pos, ref_pos)

--- a/fastf1/tests/test_input_data_handling.py
+++ b/fastf1/tests/test_input_data_handling.py
@@ -1,6 +1,7 @@
 # test some known special cases
 
 import logging
+import weakref
 
 import pandas as pd
 import pytest
@@ -70,6 +71,16 @@ def test_no_extra_lap_if_race_not_started():
     session.load(telemetry=False, weather=False)
     assert session.laps.size
     assert session.laps.pick_drivers('TSU').size == 0
+
+
+@pytest.mark.f1telapi
+def test_no_extra_lap_if_race_not_started_2():
+    # Tyre data is present for PIA, NOR, BOR, ALB, but none of them actually
+    # started the race.
+    session = fastf1.get_session(2026, "China", "R")
+    session.load(telemetry=False, weather=False)
+
+    assert session.laps.pick_drivers(['PIA', 'NOR', 'BOR', 'ALB']).size == 0
 
 
 @pytest.mark.f1telapi


### PR DESCRIPTION
### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request in your own words and link to 
  any relevant issues and PRs.

  You should also read [the contribution guide](https://docs.fastf1.dev/contributing/index.html)
  before creating a PR.
-->

This fixes #876 where an invalid first lap was added for drivers who didn't start the race (DNS). This happened because tyre data for a planned first stint was available, causing FastF1 to handle this as if the driver crashed on the first lap of the race.
Now, result data will be used (if available), to differentiate this new special case.

Using result data while loading lap timing data is not desirable, due to the mixed data sources and because the data will not be available immediately after the race. Right now, no different solution for this problem seems to exists, though.

closes #876
closes #881

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
  the tool(s) used, how they were used, and specify what code or text is AI generated.
  If no AI tools were used, please write "No AI tools used" in this section. Read our
  policy on AI generated code at
  https://docs.fastf1.dev/contributing/ai_policy.html

  It is especially important that you always interact and communicate as a human. 
  Do not submit fully AI generated pull requests or AI generated pull request descriptions
  or comments.
-->
No AI tools used