### PR TITLE
Grid average speed trace comparison (2025 vs 2026)

### DIFF
--- a/examples/telemetry/plot_annotate_speed_trace.py
+++ b/examples/telemetry/plot_annotate_speed_trace.py
@@ -1,9 +1,8 @@
-"""Plot speed traces with corner annotations
+"""Plot speed traces with corner annotationshttps://epirusbank.open-hackathon.gr/
 ============================================
 
 Plot the speed over the course of a lap and add annotations to mark corners.
 """
-
 
 import matplotlib.pyplot as plt
 
@@ -12,10 +11,10 @@ import fastf1.plotting
 
 # Enable Matplotlib patches for plotting timedelta values and load
 # FastF1's dark color scheme
-fastf1.plotting.setup_mpl(mpl_timedelta_support=True, color_scheme='fastf1')
+fastf1.plotting.setup_mpl(mpl_timedelta_support=True, color_scheme="fastf1")
 
 # load a session and its telemetry data
-session = fastf1.get_session(2021, 'Spanish Grand Prix', 'Q')
+session = fastf1.get_session(2021, "Spanish Grand Prix", "Q")
 session.load()
 
 ##############################################################################
@@ -35,30 +34,46 @@ circuit_info = session.get_circuit_info()
 # Finally, we create a plot and plot the speed trace as well as the corner
 # markers.
 
-team_color = fastf1.plotting.get_team_color(fastest_lap['Team'],
-                                            session=session)
+team_color = fastf1.plotting.get_team_color(
+    fastest_lap["Team"], session=session
+)
 
 fig, ax = plt.subplots()
-ax.plot(car_data['Distance'], car_data['Speed'],
-        color=team_color, label=fastest_lap['Driver'])
+ax.plot(
+    car_data["Distance"],
+    car_data["Speed"],
+    color=team_color,
+    label=fastest_lap["Driver"],
+)
 
 # Draw vertical dotted lines at each corner that range from slightly below the
 # minimum speed to slightly above the maximum speed.
-v_min = car_data['Speed'].min()
-v_max = car_data['Speed'].max()
-ax.vlines(x=circuit_info.corners['Distance'], ymin=v_min-20, ymax=v_max+20,
-          linestyles='dotted', colors='grey')
+v_min = car_data["Speed"].min()
+v_max = car_data["Speed"].max()
+ax.vlines(
+    x=circuit_info.corners["Distance"],
+    ymin=v_min - 20,
+    ymax=v_max + 20,
+    linestyles="dotted",
+    colors="grey",
+)
 
 # Plot the corner number just below each vertical line.
 # For corners that are very close together, the text may overlap. A more
 # complicated approach would be necessary to reliably prevent this.
 for _, corner in circuit_info.corners.iterrows():
     txt = f"{corner['Number']}{corner['Letter']}"
-    ax.text(corner['Distance'], v_min-30, txt,
-            va='center_baseline', ha='center', size='small')
+    ax.text(
+        corner["Distance"],
+        v_min - 30,
+        txt,
+        va="center_baseline",
+        ha="center",
+        size="small",
+    )
 
-ax.set_xlabel('Distance in m')
-ax.set_ylabel('Speed in km/h')
+ax.set_xlabel("Distance in m")
+ax.set_ylabel("Speed in km/h")
 ax.legend()
 
 # Manually adjust the y-axis limits to include the corner numbers, because

--- a/examples/telemetry/plot_annotate_speed_trace.py
+++ b/examples/telemetry/plot_annotate_speed_trace.py
@@ -1,8 +1,9 @@
-"""Plot speed traces with corner annotationshttps://epirusbank.open-hackathon.gr/
+"""Plot speed traces with corner annotations
 ============================================
 
 Plot the speed over the course of a lap and add annotations to mark corners.
 """
+
 
 import matplotlib.pyplot as plt
 
@@ -11,10 +12,10 @@ import fastf1.plotting
 
 # Enable Matplotlib patches for plotting timedelta values and load
 # FastF1's dark color scheme
-fastf1.plotting.setup_mpl(mpl_timedelta_support=True, color_scheme="fastf1")
+fastf1.plotting.setup_mpl(mpl_timedelta_support=True, color_scheme='fastf1')
 
 # load a session and its telemetry data
-session = fastf1.get_session(2021, "Spanish Grand Prix", "Q")
+session = fastf1.get_session(2021, 'Spanish Grand Prix', 'Q')
 session.load()
 
 ##############################################################################
@@ -34,46 +35,30 @@ circuit_info = session.get_circuit_info()
 # Finally, we create a plot and plot the speed trace as well as the corner
 # markers.
 
-team_color = fastf1.plotting.get_team_color(
-    fastest_lap["Team"], session=session
-)
+team_color = fastf1.plotting.get_team_color(fastest_lap['Team'],
+                                            session=session)
 
 fig, ax = plt.subplots()
-ax.plot(
-    car_data["Distance"],
-    car_data["Speed"],
-    color=team_color,
-    label=fastest_lap["Driver"],
-)
+ax.plot(car_data['Distance'], car_data['Speed'],
+        color=team_color, label=fastest_lap['Driver'])
 
 # Draw vertical dotted lines at each corner that range from slightly below the
 # minimum speed to slightly above the maximum speed.
-v_min = car_data["Speed"].min()
-v_max = car_data["Speed"].max()
-ax.vlines(
-    x=circuit_info.corners["Distance"],
-    ymin=v_min - 20,
-    ymax=v_max + 20,
-    linestyles="dotted",
-    colors="grey",
-)
+v_min = car_data['Speed'].min()
+v_max = car_data['Speed'].max()
+ax.vlines(x=circuit_info.corners['Distance'], ymin=v_min-20, ymax=v_max+20,
+          linestyles='dotted', colors='grey')
 
 # Plot the corner number just below each vertical line.
 # For corners that are very close together, the text may overlap. A more
 # complicated approach would be necessary to reliably prevent this.
 for _, corner in circuit_info.corners.iterrows():
     txt = f"{corner['Number']}{corner['Letter']}"
-    ax.text(
-        corner["Distance"],
-        v_min - 30,
-        txt,
-        va="center_baseline",
-        ha="center",
-        size="small",
-    )
+    ax.text(corner['Distance'], v_min-30, txt,
+            va='center_baseline', ha='center', size='small')
 
-ax.set_xlabel("Distance in m")
-ax.set_ylabel("Speed in km/h")
+ax.set_xlabel('Distance in m')
+ax.set_ylabel('Speed in km/h')
 ax.legend()
 
 # Manually adjust the y-axis limits to include the corner numbers, because

--- a/examples/telemetry/plot_speed_trace_comparison.py
+++ b/examples/telemetry/plot_speed_trace_comparison.py
@@ -1,0 +1,121 @@
+# %%
+"""
+Grid Average Speed Trace: 2025 vs 2026
+======================================
+
+Compare the average speed trace of the Top 10 drivers on a long straight
+between two different regulation eras (2025 vs 2026).
+This visualization highlights the 'clipping' effect of the 2026 Power Units.
+"""
+
+import os
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import fastf1
+import fastf1.plotting
+from fastf1.logger import get_logger
+
+
+##############################################################################
+# Setup logging and cache. We use the FastF1 logger to remain compliant
+# with the library's internal standards.
+
+logger = get_logger(__name__)
+os.makedirs('f1cache', exist_ok=True)
+fastf1.Cache.enable_cache('f1cache')
+fastf1.plotting.setup_mpl()
+
+##############################################################################
+# Define the session parameters. We compare the Qualifying sessions
+# of the Chinese Grand Prix.
+
+year_old = 2025
+year_new = 2026
+track = 'China'
+session_type = 'Q'
+
+##############################################################################
+# Load the sessions and their respective laps.
+
+session_old = fastf1.get_session(year_old, track, session_type)
+session_new = fastf1.get_session(year_new, track, session_type)
+session_old.load()
+session_new.load()
+
+##############################################################################
+# Define a helper function for data interpolation.
+# Since telemetry samples occur at different distances for each driver, 
+# we must interpolate them onto a common distance axis to calculate 
+# a mathematical average.
+#
+# The linear interpolation follows the formula:
+#
+# .. math:: y = y_0 + (x - x_0) \frac{y_1 - y_0}{x_1 - x_0}
+
+def get_average_speed(session, distance_array, year_label):
+    """Interpolates speed for Top 10 drivers and returns the average."""
+    logger.info(f"Processing telemetry for {year_label}...")
+    speeds = []
+    top_10_drivers = session.results['Abbreviation'][:10]
+
+    for driver in top_10_drivers:
+        lap = session.laps.pick_drivers(driver).pick_fastest()
+
+        if pd.isna(lap['LapTime']):
+            continue
+
+        tel = lap.get_telemetry().add_distance()
+        # Crop telemetry to the back straight area (Shanghai)
+        mask = (tel['Distance'] >= 3700) & (tel['Distance'] <= 4800)
+        tel_straight = tel[mask]
+
+        interp_speed = np.interp(
+            distance_array,
+            tel_straight['Distance'],
+            tel_straight['Speed']
+        )
+        speeds.append(interp_speed)
+
+    return np.mean(speeds, axis=0)
+
+##############################################################################
+# Calculate the average speed traces for both years using a 
+# common distance grid.
+
+common_distance = np.linspace(3800, 4750, 500)
+avg_speed_old = get_average_speed(session_old, common_distance, year_old)
+avg_speed_new = get_average_speed(session_new, common_distance, year_new)
+
+##############################################################################
+# Create the visualization. We highlight the speed delta (clipping)
+# using a shaded area between the two traces.
+
+fig, ax = plt.subplots(figsize=(10, 6))
+
+ax.plot(
+    common_distance, avg_speed_old,
+    label=f'{year_old} (Top 10 Avg - DRS Era)',
+    color='grey', linestyle='--'
+)
+ax.plot(
+    common_distance, avg_speed_new,
+    label=f'{year_new} (Top 10 Avg - Current)',
+    color='red', linewidth=2.5
+)
+
+ax.fill_between(
+    common_distance, avg_speed_new, avg_speed_old,
+    where=(avg_speed_old > avg_speed_new),
+    color='red', alpha=0.2, label='Speed Loss (Clipping)'
+)
+
+ax.set_title(
+    f"Grid Average Speed Trace: Shanghai Back Straight\n"
+    f"({year_old} vs {year_new}) - Top 10 Qualifiers"
+)
+ax.set_xlabel("Distance (m)")
+ax.set_ylabel("Speed (km/h)")
+ax.legend()
+
+plt.show()

--- a/examples/telemetry/plot_speed_trace_comparison.py
+++ b/examples/telemetry/plot_speed_trace_comparison.py
@@ -1,4 +1,3 @@
-# %%
 """
 Grid Average Speed Trace: 2025 vs 2026
 ======================================
@@ -8,22 +7,17 @@ between two different regulation eras (2025 vs 2026).
 This visualization highlights the 'clipping' effect of the 2026 Power Units.
 """
 
-import os
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+
 import fastf1
 import fastf1.plotting
-from fastf1.logger import get_logger
 
 
 ##############################################################################
-# Setup logging and cache. We use the FastF1 logger to remain compliant
-# with the library's internal standards.
+# Enable FastF1's plotting settings (dark theme etc.)
 
-logger = get_logger(__name__)
-os.makedirs('f1cache', exist_ok=True)
-fastf1.Cache.enable_cache('f1cache')
 fastf1.plotting.setup_mpl()
 
 ##############################################################################
@@ -32,11 +26,11 @@ fastf1.plotting.setup_mpl()
 
 year_old = 2025
 year_new = 2026
-track = 'China'
-session_type = 'Q'
+track = "China"
+session_type = "Q"
 
 ##############################################################################
-# Load the sessions and their respective laps.
+# Load the sessions.
 
 session_old = fastf1.get_session(year_old, track, session_type)
 session_new = fastf1.get_session(year_new, track, session_type)
@@ -45,47 +39,43 @@ session_new.load()
 
 ##############################################################################
 # Define a helper function for data interpolation.
-# Since telemetry samples occur at different distances for each driver, 
-# we must interpolate them onto a common distance axis to calculate 
+# Since telemetry samples occur at different distances for each driver,
+# we must interpolate them onto a common distance axis to calculate
 # a mathematical average.
-#
-# The linear interpolation follows the formula:
-#
-# .. math:: y = y_0 + (x - x_0) \frac{y_1 - y_0}{x_1 - x_0}
 
-def get_average_speed(session, distance_array, year_label):
+
+def get_average_speed(session, distance_array):
     """Interpolates speed for Top 10 drivers and returns the average."""
-    logger.info(f"Processing telemetry for {year_label}...")
     speeds = []
-    top_10_drivers = session.results['Abbreviation'][:10]
+    top_10_drivers = session.results["Abbreviation"][:10]
 
     for driver in top_10_drivers:
         lap = session.laps.pick_drivers(driver).pick_fastest()
 
-        if pd.isna(lap['LapTime']):
+        if pd.isna(lap["LapTime"]):
             continue
 
         tel = lap.get_telemetry().add_distance()
+
         # Crop telemetry to the back straight area (Shanghai)
-        mask = (tel['Distance'] >= 3700) & (tel['Distance'] <= 4800)
+        mask = (tel["Distance"] >= 3700) & (tel["Distance"] <= 4800)
         tel_straight = tel[mask]
 
         interp_speed = np.interp(
-            distance_array,
-            tel_straight['Distance'],
-            tel_straight['Speed']
+            distance_array, tel_straight["Distance"], tel_straight["Speed"]
         )
         speeds.append(interp_speed)
 
     return np.mean(speeds, axis=0)
 
+
 ##############################################################################
-# Calculate the average speed traces for both years using a 
+# Calculate the average speed traces for both years using a
 # common distance grid.
 
 common_distance = np.linspace(3800, 4750, 500)
-avg_speed_old = get_average_speed(session_old, common_distance, year_old)
-avg_speed_new = get_average_speed(session_new, common_distance, year_new)
+avg_speed_old = get_average_speed(session_old, common_distance)
+avg_speed_new = get_average_speed(session_new, common_distance)
 
 ##############################################################################
 # Create the visualization. We highlight the speed delta (clipping)
@@ -94,20 +84,28 @@ avg_speed_new = get_average_speed(session_new, common_distance, year_new)
 fig, ax = plt.subplots(figsize=(10, 6))
 
 ax.plot(
-    common_distance, avg_speed_old,
-    label=f'{year_old} (Top 10 Avg - DRS Era)',
-    color='grey', linestyle='--'
+    common_distance,
+    avg_speed_old,
+    label=f"{year_old} (Top 10 Avg - DRS Era)",
+    color="grey",
+    linestyle="--",
 )
 ax.plot(
-    common_distance, avg_speed_new,
-    label=f'{year_new} (Top 10 Avg - Current)',
-    color='red', linewidth=2.5
+    common_distance,
+    avg_speed_new,
+    label=f"{year_new} (Top 10 Avg - Current)",
+    color="red",
+    linewidth=2.5,
 )
 
 ax.fill_between(
-    common_distance, avg_speed_new, avg_speed_old,
+    common_distance,
+    avg_speed_new,
+    avg_speed_old,
     where=(avg_speed_old > avg_speed_new),
-    color='red', alpha=0.2, label='Speed Loss (Clipping)'
+    color="red",
+    alpha=0.2,
+    label="Speed Loss (Clipping)",
 )
 
 ax.set_title(

--- a/examples/telemetry/plot_speed_trace_comparison.py
+++ b/examples/telemetry/plot_speed_trace_comparison.py
@@ -18,7 +18,7 @@ import fastf1.plotting
 ##############################################################################
 # Enable FastF1's plotting settings (dark theme etc.)
 
-fastf1.plotting.setup_mpl()
+fastf1.plotting.setup_mpl(color_scheme="fastf1")
 
 ##############################################################################
 # Define the session parameters. We compare the Qualifying sessions
@@ -44,7 +44,9 @@ session_new.load()
 # a mathematical average.
 
 
-def get_average_speed(session, distance_array):
+def get_average_speed(
+    session: fastf1.core.Session, distance_array: np.ndarray
+):
     """Interpolates speed for Top 10 drivers and returns the average.
 
     Args:

--- a/examples/telemetry/plot_speed_trace_comparison.py
+++ b/examples/telemetry/plot_speed_trace_comparison.py
@@ -45,7 +45,18 @@ session_new.load()
 
 
 def get_average_speed(session, distance_array):
-    """Interpolates speed for Top 10 drivers and returns the average."""
+    """Interpolates speed for Top 10 drivers and returns the average.
+
+    Args:
+        session (fastf1.core.Session): The loaded FastF1 session
+            object containing the telemetry and lap data.
+        distance_array (np.ndarray): A 1D numpy array of distances
+            used as the common grid for mathematical interpolation.
+
+    Returns:
+        np.ndarray: A 1D numpy array containing the calculated average
+        speeds corresponding to each point in the distance_array.
+    """
     speeds = []
     top_10_drivers = session.results["Abbreviation"][:10]
 


### PR DESCRIPTION
Since the 2026 regulations don't have explicit "Aero Mode" or "Battery State" telemetry channels in the API yet (as discussed in #864), I wanted to create a data-driven workaround to visualize the new Power Unit behavior.

By using `np.interp` to align the speed data of the Top 10 drivers on the Shanghai back straight onto a common distance grid, and then averaging it, we remove individual driver noise. This allows us to clearly see the "clipping" effect of the new 2026 rules compared to the 2025 DRS era.

#### AI Disclosure
**Tools used:** Google Gemini
**How it was used:** I used Gemini primarily as a logic debugger to verify my approach with `np.interp`.
**What is AI generated:** No core logic or executable code was generated by AI. Gemini only assisted in reformatting my original Google-style docstrings to strictly comply with the Sphinx/Napoleon syntax requirements and fixing PEP8 line-length warnings. The concept, the data workaround, the implementation, and the testing are entirely my own work.