### PR TITLE
prevent fuzzy match of 'Pre-Season Testing' to race events

### DIFF
--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -230,14 +230,27 @@ def get_event(
         :class:`KeyError`: ``exact_match`` is ``True`` and no exact
             match exists.
     """
-    schedule = get_event_schedule(year=year,
-                                  include_testing=False,
-                                  backend=backend)
-
     if isinstance(gp, str):
-        event = schedule.get_event_by_name(
-            gp, exact_match=exact_match)
+        # Check for exact match against testing events first, before
+        # fuzzy searching race events. This prevents names like
+        # 'Pre-Season Testing' from being incorrectly fuzzy-matched
+        # to a race event (e.g. Singapore GP). Fixes #851.
+        full_schedule = get_event_schedule(year=year,
+                                           include_testing=True,
+                                           backend=backend)
+        testing_only = full_schedule[full_schedule.is_testing()]
+        if len(testing_only) > 0:
+            try:
+                return testing_only._strict_event_search(gp)
+            except KeyError:
+                pass  # no exact testing match, fall through to fuzzy search
+
+        schedule = full_schedule[~full_schedule.is_testing()]
+        event = schedule.get_event_by_name(gp, exact_match=exact_match)
     else:
+        schedule = get_event_schedule(year=year,
+                                      include_testing=False,
+                                      backend=backend)
         event = schedule.get_event_by_round(gp)
 
     return event

--- a/fastf1/tests/test_events.py
+++ b/fastf1/tests/test_events.py
@@ -62,6 +62,22 @@ def test_get_event_round_zero():
     with pytest.raises(ValueError, match="testing event by round number"):
         fastf1.get_event(2021, 0)
 
+def test_get_event_pre_season_testing():
+    """Regression test for GH#851.
+
+    'Pre-Season Testing' was incorrectly fuzzy-matched to Singapore GP
+    because get_event() excluded testing events before searching.
+    """
+    event = fastf1.get_event(2026, 'Pre-Season Testing')
+    assert event['EventFormat'] == 'testing'
+    assert 'testing' in event['EventName'].casefold()
+
+
+def test_get_session_pre_season_testing():
+    """Regression test for GH#851 - session level check."""
+    session = fastf1.get_session(2026, 'Pre-Season Testing', 'Practice 1')
+    assert session.event['EventFormat'] == 'testing'
+    assert session.name == 'Practice 1'
 
 def test_get_testing_event():
     # 0 is not a valid number for a testing event


### PR DESCRIPTION
## Problem
Fixes #851

`get_session(2026, 'Pre-Season Testing', 'Practice 1')` incorrectly
resolved to 'Singapore Grand Prix' instead of the testing event.

## Root Cause
`get_event()` was calling `get_event_schedule()` with
`include_testing=False`, so testing events were completely excluded
from the fuzzy search pool. With no correct candidate available,
the fuzzy matcher picked Singapore GP as the closest wrong match.

## Fix
Before falling through to fuzzy search on race events, we now attempt
an exact (case-insensitive) match against testing events from the full
schedule. If matched, it returns immediately. If not, behaviour is
identical to before.

## Tests
Added two regression tests:
- `test_get_event_pre_season_testing` — verifies event format is testing
- `test_get_session_pre_season_testing` — verifies session resolves correctly