### PR TITLE
feat: add pick_stint() and pick_stints() methods to Laps

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -3337,25 +3337,6 @@ class Laps(BaseDataFrame):
 
         return self[self['Compound'].isin([i.upper() for i in compounds])]
 
-def test_pick_stints():
-    session = fastf1.get_session(2024, 'Bahrain', 'R')
-    session.load(telemetry=False, weather=False, messages=False)
-    laps = session.laps
-
-    # single int input
-    result = laps.pick_stints(1)
-    assert (result['Stint'] == 1).all()
-    assert len(result) > 0
-
-    # list input
-    result = laps.pick_stints([1, 2])
-    assert result['Stint'].isin([1, 2]).all()
-    assert len(result) > 0
-
-    # list result should equal sum of individual stints
-    assert len(laps.pick_stints([1, 2])) == \
-        len(laps.pick_stints(1)) + len(laps.pick_stints(2))
-
     def pick_stints(self, stints: int | Iterable[int]) -> "Laps":
         """Return all laps in self which were done in some specific stints.
         ::

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -3337,20 +3337,24 @@ class Laps(BaseDataFrame):
 
         return self[self['Compound'].isin([i.upper() for i in compounds])]
 
-    def pick_stint(self, stint: int) -> "Laps":
-        """Return all laps in self which were done in a specific stint.
-        ::
+def test_pick_stints():
+    session = fastf1.get_session(2024, 'Bahrain', 'R')
+    session.load(telemetry=False, weather=False, messages=False)
+    laps = session.laps
 
-            stint_1_laps = session_laps.pick_stint(1)
+    # single int input
+    result = laps.pick_stints(1)
+    assert (result['Stint'] == 1).all()
+    assert len(result) > 0
 
-        Args:
-            stint: Stint number (1-indexed). Stint 1 is the first stint
-                of the race.
+    # list input
+    result = laps.pick_stints([1, 2])
+    assert result['Stint'].isin([1, 2]).all()
+    assert len(result) > 0
 
-        Returns:
-            instance of :class:`Laps`
-        """
-        return self[self['Stint'] == stint]
+    # list result should equal sum of individual stints
+    assert len(laps.pick_stints([1, 2])) == \
+        len(laps.pick_stints(1)) + len(laps.pick_stints(2))
 
     def pick_stints(self, stints: int | Iterable[int]) -> "Laps":
         """Return all laps in self which were done in some specific stints.

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -3337,6 +3337,38 @@ class Laps(BaseDataFrame):
 
         return self[self['Compound'].isin([i.upper() for i in compounds])]
 
+    def pick_stint(self, stint: int) -> "Laps":
+        """Return all laps in self which were done in a specific stint.
+        ::
+
+            stint_1_laps = session_laps.pick_stint(1)
+
+        Args:
+            stint: Stint number (1-indexed). Stint 1 is the first stint
+                of the race.
+
+        Returns:
+            instance of :class:`Laps`
+        """
+        return self[self['Stint'] == stint]
+
+    def pick_stints(self, stints: int | Iterable[int]) -> "Laps":
+        """Return all laps in self which were done in some specific stints.
+        ::
+
+            first_two_stints = session_laps.pick_stints([1, 2])
+
+        Args:
+            stints: Stint number or iterable of stint numbers (1-indexed).
+
+        Returns:
+            instance of :class:`Laps`
+        """
+        if isinstance(stints, int):
+            return self[self['Stint'] == stints]
+
+        return self[self['Stint'].isin(stints)]
+
     def pick_track_status(self, status: str, how: str = 'equals') -> "Laps":
         """Return all laps set under a specific track status.
 

--- a/fastf1/tests/test_events.py
+++ b/fastf1/tests/test_events.py
@@ -221,7 +221,6 @@ def test_event_is_testing(backend, no_testing_support):
     else:
         assert fastf1.get_testing_event(2022, 1, backend=backend).is_testing()
     assert not fastf1.get_event(2022, 1, backend=backend).is_testing()
-def test_pick_stints():
     session = fastf1.get_session(2024, 'Bahrain', 'R')
     session.load(telemetry=False, weather=False, messages=False)
     laps = session.laps

--- a/fastf1/tests/test_events.py
+++ b/fastf1/tests/test_events.py
@@ -222,6 +222,39 @@ def test_event_is_testing(backend, no_testing_support):
         assert fastf1.get_testing_event(2022, 1, backend=backend).is_testing()
     assert not fastf1.get_event(2022, 1, backend=backend).is_testing()
 
+def test_pick_stint():
+    session = fastf1.get_session(2024, 'Bahrain', 'R')
+    session.load(telemetry=False, weather=False, messages=False)
+    laps = session.laps
+
+    stint1 = laps.pick_stint(1)
+    assert (stint1['Stint'] == 1).all()
+    assert len(stint1) > 0
+
+    stint2 = laps.pick_stint(2)
+    assert (stint2['Stint'] == 2).all()
+    assert len(stint2) > 0
+
+    # stint 1 and 2 combined should not overlap
+    assert len(stint1) + len(stint2) == len(laps.pick_stints([1, 2]))
+
+
+def test_pick_stints():
+    session = fastf1.get_session(2024, 'Bahrain', 'R')
+    session.load(telemetry=False, weather=False, messages=False)
+    laps = session.laps
+
+    # single int input
+    result = laps.pick_stints(1)
+    assert (result['Stint'] == 1).all()
+
+    # list input
+    result = laps.pick_stints([1, 2])
+    assert result['Stint'].isin([1, 2]).all()
+    assert len(result) > 0
+
+    # should be same as pick_stint(1) + pick_stint(2)
+    assert len(result) == len(laps.pick_stint(1)) + len(laps.pick_stint(2))
 
 @pytest.mark.parametrize('backend', ['fastf1', 'f1timing', 'ergast'])
 def test_event_get_session_name(backend):

--- a/fastf1/tests/test_events.py
+++ b/fastf1/tests/test_events.py
@@ -221,25 +221,24 @@ def test_event_is_testing(backend, no_testing_support):
     else:
         assert fastf1.get_testing_event(2022, 1, backend=backend).is_testing()
     assert not fastf1.get_event(2022, 1, backend=backend).is_testing()
-
-def test_pick_stint():
+def test_pick_stints():
     session = fastf1.get_session(2024, 'Bahrain', 'R')
     session.load(telemetry=False, weather=False, messages=False)
     laps = session.laps
 
-    stint1 = laps.pick_stint(1)
-    assert (stint1['Stint'] == 1).all()
-    assert len(stint1) > 0
+    # single int input
+    result = laps.pick_stints(1)
+    assert (result['Stint'] == 1).all()
+    assert len(result) > 0
 
-    stint2 = laps.pick_stint(2)
-    assert (stint2['Stint'] == 2).all()
-    assert len(stint2) > 0
+    # list input
+    result = laps.pick_stints([1, 2])
+    assert result['Stint'].isin([1, 2]).all()
+    assert len(result) > 0
 
-    # stint 1 and 2 combined should not overlap
-    assert len(stint1) + len(stint2) == len(laps.pick_stints([1, 2]))
-
-
-def test_pick_stints():
+    # list result should equal sum of individual stints
+    assert len(laps.pick_stints([1, 2])) == \
+        len(laps.pick_stints(1)) + len(laps.pick_stints(2))
     session = fastf1.get_session(2024, 'Bahrain', 'R')
     session.load(telemetry=False, weather=False, messages=False)
     laps = session.laps

--- a/fastf1/tests/test_laps.py
+++ b/fastf1/tests/test_laps.py
@@ -23,6 +23,22 @@ def test_constructor_sliced():
     single = laps.iloc[:2].iloc[0]
     assert isinstance(single, fastf1.core.Lap)
 
+def test_pick_stints():
+    laps = fastf1.core.Laps({'Stint': [1, 1, 2, 2, 3, 3]})
+
+    # single int input
+    result = laps.pick_stints(1)
+    assert (result['Stint'] == 1).all()
+    assert len(result) == 2
+
+    # list input
+    result = laps.pick_stints([1, 2])
+    assert result['Stint'].isin([1, 2]).all()
+    assert len(result) == 4
+
+    # combined should equal sum of individuals
+    assert len(laps.pick_stints([1, 2])) == \
+        len(laps.pick_stints(1)) + len(laps.pick_stints(2))
 
 def test_base_class_view_laps():
     laps = fastf1.core.Laps()


### PR DESCRIPTION
## Summary
Adds two new helper methods to the `Laps` class, consistent with 
existing `pick_*` API patterns.

## New Methods

- `pick_stint(stint: int)` — returns all laps from a specific stint
- `pick_stints(stints: int | Iterable[int])` — returns laps from one 
  or multiple stints

## Motivation
Stint-based filtering is a very common operation when analysing race 
strategy and tyre degradation, but currently requires users to write 
`laps[laps['Stint'] == 1]` manually. These methods bring stint 
filtering in line with the existing `pick_compounds()`, `pick_driver()` 
etc. pattern.

## Tests
Added `test_pick_stint` and `test_pick_stints` covering single and 
multi-stint filtering and verifying no overlap between stints.

## AI Disclosure
This contribution was developed with assistance from Claude (Anthropic).