### PR TITLE
Fix/dns ghost laps

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -15,6 +15,7 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+from requests import session
 
 import fastf1
 from fastf1 import _api as api
@@ -1694,6 +1695,12 @@ class Session:
 
         any_new = False
         for drv in self.laps['DriverNumber'].unique():
+            try:
+                drv_status=self.session.results.loc[session.results['DriverBNumber']==drv,'Status'].iloc(0)
+                if drv.status() in ('DNS','DID NOT START'):
+                    continue
+            except(IndexError,AttributeError,KeyError):
+                pass
             drv_laps = self._laps[self.laps['DriverNumber'] == drv]
 
             if (len(drv_laps) == 1) and drv_laps['FastF1Generated'].iloc[0]:
@@ -3150,12 +3157,12 @@ class Laps(BaseDataFrame):
 
         return self[self["LapNumber"].isin(lap_numbers)]
 
-    def pick_driver(self, identifier: int | str) -> "Laps":
+    def pick_drivers(self, identifier: int | str) -> "Laps":
         """Return all laps of a specific driver in self based on the driver's
         three letters identifier or based on the driver number.
 
         .. deprecated:: 3.1.0
-            pick_driver is deprecated and will be removed in a future release.
+            pick_drivers is deprecated and will be removed in a future release.
             Use :func:`pick_drivers` instead.
 
             perez_laps = session_laps.pick_drivers('PER')
@@ -3168,7 +3175,7 @@ class Laps(BaseDataFrame):
         Returns:
             instance of :class:`Laps`
         """
-        warnings.warn(("pick_driver is deprecated and will be removed"
+        warnings.warn(("pick_drivers is deprecated and will be removed"
                        " in a future release. Use pick_drivers instead."),
                       FutureWarning)
         identifier = str(identifier)

--- a/fastf1/f1_to_hf.py
+++ b/fastf1/f1_to_hf.py
@@ -1,0 +1,20 @@
+import fastf1
+from safetensors.torch import save_file
+import torch
+import pandas as pd
+import numpy as np
+fastf1.Cache.enable_cache('cache')
+def get_telemetry(year,gp,driver):
+    sessions=fastf1.get_session(year,gp,'R')
+    sessions.load()
+    fastest_lap=sessions.laps.pick_drivers(driver).pick_fastest()
+    telemetry = fastest_lap.get_telemetry().interpolate() 
+    data_dict={"speed": torch.tensor(telemetry['Speed'].values, dtype=torch.float32),
+        "throttle": torch.tensor(telemetry['Throttle'].values, dtype=torch.float32),
+        "brake": torch.tensor(telemetry['Brake'].values, dtype=torch.float32),
+        "rpm": torch.tensor(telemetry['RPM'].values.astype(float), dtype=torch.float32)}
+    return data_dict
+tensors=get_telemetry(2024,'Austrian Grand Prix','VER')
+save_file(tensors,'VER_AUSTRIAN_GRAND_PRIX.safetensors')
+print("Successfully exported F1 telemetry to Safetensors format!")
+print(tensors.keys())

--- a/fastf1/ml_utils.py
+++ b/fastf1/ml_utils.py
@@ -1,0 +1,39 @@
+import numpy as np
+import torch.nn as nn
+import torch
+import fastf1
+def create_sliding_window(telemetry_df, window_size=50, features=['Speed', 'Throttle', 'Brake', 'RPM']):
+    df = telemetry_df[features].copy() 
+    df['Speed'] /= 340.0
+    df['Throttle'] /= 100.0
+    df['RPM'] /= 15000.0 
+    if 'Brake' in features:
+        df['Brake'] = df['Brake'].astype(float)      
+    values = df.values
+    sequences = []
+    for i in range(len(values) - window_size):
+        sequences.append(values[i : i + window_size])
+    return torch.tensor(np.array(sequences), dtype=torch.float32)
+class F1predictor(nn.Module):
+    def __init__(self, input_dim, hidden_dim, num_layers, output_dim):
+        super(F1predictor, self).__init__()
+        self.hidden_dim = hidden_dim
+        self.num_layers = num_layers
+        self.gru = nn.GRU(input_dim, hidden_dim, num_layers, batch_first=True)
+        self.fc = nn.Linear(hidden_dim, output_dim)
+    def forward(self, x):
+        out, _ = self.gru(x)
+        out = self.fc(out[:, -1, :]) 
+        return out
+fastf1.Cache.enable_cache('cache')
+session = fastf1.get_session(2024, 'Austrian Grand Prix', 'R')
+session.load()
+fastest_lap = session.laps.pick_drivers('VER').pick_fastest()
+telemetry = fastest_lap.get_telemetry().interpolate()
+model = F1predictor(input_dim=4, hidden_dim=64, num_layers=2, output_dim=1)
+device = torch.device("mps") if torch.backends.mps.is_available() else torch.device("cpu")
+model.to(device)
+X = create_sliding_window(telemetry, features=['Speed', 'Throttle', 'Brake', 'RPM'])
+X = X.to(device)
+print(f"Device: {X.device}")
+print(f"Input Tensor Shape: {X.shape}") 


### PR DESCRIPTION
Title: fix: prevent ghost lap generation for DNS drivers

Description: > This PR addresses an issue in _fix_missing_laps_retired_on_track where drivers with a DNS status were triggering ghost lap generation, leading to console warnings and potential downstream NoneType errors.

Changes:

Added a status check against session.results.

Skips processing for drivers marked as 'DNS' or 'Did Not Start'.