### PR TITLE
fix: prevent ghost lap generation for DNS drivers

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1694,6 +1694,12 @@ class Session:
 
         any_new = False
         for drv in self.laps['DriverNumber'].unique():
+            try:
+                drv_status = self.session.results.loc[drv, 'Status']
+                if drv_status.upper() in ['DNS', 'DID NOT START']:
+                    continue 
+            except (KeyError, AttributeError):
+                pass
             drv_laps = self._laps[self.laps['DriverNumber'] == drv]
 
             if (len(drv_laps) == 1) and drv_laps['FastF1Generated'].iloc[0]:


### PR DESCRIPTION
Added a status check against self.session.results. If a driver is marked as 'DNS' or 'DID NOT START', the logic gracefully skips lap generation for that driver number.