### PR TITLE
MNT: deprecate round kwarg in events.py (#890)

### DIFF
--- a/docs/changelog/current.rst
+++ b/docs/changelog/current.rst
@@ -1,3 +1,16 @@
+What's new in v3.9.0
+--------------------
+
+(in development)
+
+
+Deprecations
+^^^^^^^^^^^^
+
+- The ``round`` keyword argument of ``EventSchedule.get_event_by_round`` is
+  deprecated and will be removed in a future version. Use ``round_number``
+  instead. (#890)
+
 What's new in v3.8.3
 --------------------
 

--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -1,6 +1,7 @@
 import collections
 import datetime
 import json
+import warnings
 from typing import Literal
 
 import dateutil.parser
@@ -696,19 +697,47 @@ class EventSchedule(BaseDataFrame):
         testing event."""
         return pd.Series(self['EventFormat'] == 'testing')
 
-    def get_event_by_round(self, round: int) -> "Event":
+    def get_event_by_round(
+            self,
+            round_number: int | None = None,
+            *,
+            round: int | None = None) -> "Event":
         """Get an :class:`Event` by its round number.
 
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
+
         Args:
-            round: The round number
+            round_number: The round number
         Raises:
             ValueError: The round does not exist in the event schedule
         """
-        if round == 0:
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
+        if round_number is None:
+            raise ValueError(
+                "get_event_by_round() missing 1 required argument: "
+                "'round_number'"
+            )
+
+        if round_number == 0:
             raise ValueError("Cannot get testing event by round number!")
-        mask = self['RoundNumber'] == round
+        mask = self['RoundNumber'] == round_number
         if not mask.any():
-            raise ValueError(f"Invalid round: {round}")
+            raise ValueError(f"Invalid round: {round_number}")
         return self[mask].iloc[0]
 
     def _strict_event_search(self, name: str) -> "Event":

--- a/fastf1/tests/test_events.py
+++ b/fastf1/tests/test_events.py
@@ -117,6 +117,26 @@ def test_event_schedule_get_event_by_round_number():
         schedule.get_event_by_round(10)
 
 
+def test_event_schedule_get_event_by_round_deprecated_kwarg():
+    schedule = fastf1.events.EventSchedule(
+        {'EventName': ['T1', 'A', 'B', 'C', 'D'],
+         'RoundNumber': [0, 1, 2, 3, 4]}
+    )
+    # Deprecated `round` kwarg still works but emits FutureWarning
+    with pytest.warns(FutureWarning, match="deprecated"):
+        event = schedule.get_event_by_round(round=2)
+    assert event['EventName'] == 'B'
+    # Passing both raises ValueError (and emits the warning first)
+    with (
+        pytest.warns(FutureWarning, match="deprecated"),
+        pytest.raises(ValueError, match="Cannot pass both"),
+    ):
+        schedule.get_event_by_round(round_number=2, round=2)
+    # Passing neither raises ValueError
+    with pytest.raises(ValueError, match="missing 1 required argument"):
+        schedule.get_event_by_round()
+
+
 def test_event_schedule_get_by_name():
     schedule = fastf1.events.EventSchedule(
         {


### PR DESCRIPTION
First step towards #890. Deprecating the `round` kwarg on `get_event_by_round` as a pilot before doing the other 13 functions.

Changes:
- events.py: added `round_number` kwarg, kept `round` as keyword-only with FutureWarning, TypeError if both or neither passed
- test_events.py: new test for the deprecated path, both-passed, and neither-passed
- changelog: Deprecations entry under v3.9.0

Not touching the other 13 functions or pyproject.toml in this PR, wanted to check the pattern first.

Is this the right shape? Open to feedback on the warning message, error wording, or anything else before I apply it to the rest.

AI disclosure: used Claude for navigating the codebase and grammar review on this PR description. All code typed and reviewed by me.