### PR TITLE
Add TeamId and DriverId to F1 API driver info for FP sessions (fix #811)

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -2467,10 +2467,12 @@ class Session:
                 'Tla': 'Abbreviation',
                 'TeamName': 'TeamName',
                 'TeamColour': 'TeamColor',
+                'TeamId': 'TeamId',
                 'FirstName': 'FirstName',
                 'LastName': 'LastName',
                 'HeadshotUrl': 'HeadshotUrl',
-                'CountryCode': 'CountryCode'
+                'CountryCode': 'CountryCode',
+                'DriverId': 'DriverId'
             }.items():
                 for entry in f1di.values():
                     driver_info[key2].append(entry.get(key1))


### PR DESCRIPTION
## Summary

The F1 API provides TeamId and DriverId for drivers, but `_drivers_from_f1_api` was not collecting these fields. For FP sessions where Ergast data is not available (only race session data is used from Ergast for practice sessions), these fields would be missing entirely.

This adds TeamId and DriverId to the F1 API driver info mapping so that FP session results include these fields.

## Fix

Added `TeamId` and `DriverId` to the field mapping in `_drivers_from_f1_api()`.

## Testing

Unable to test locally due to data fetching requirements. The fix follows the existing pattern in the code for other fields from the F1 API.

## Checklist

- [x] Code follows the project's coding conventions
- [x] Fix addresses the issue described in #811

## AI Disclosure

AI was used as a coding assistant. The human author reviewed all AI-generated code and changes.