### PR TITLE
Fix NaT lap times after red flag restarts (issue #473)

### DIFF
--- a/fastf1/_api.py
+++ b/fastf1/_api.py
@@ -663,6 +663,11 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
 
     # more lap sync, this time check which lap triggered with the lowest latency
     for i in range(len(drv_data['Time']) - 1, 0, -1):
+        if pd.isna(drv_data['LapTime'][i]):
+            # LapTime can be NaT for formation laps and other special cases
+            # (e.g., standing restarts after red flags). In these cases, no
+            # lap time sync adjustment should be performed.
+            continue
         if (new_time := drv_data['Time'][i] - drv_data['LapTime'][i]) < \
                 drv_data['Time'][i - 1]:
             if i > 1 and new_time < drv_data['Time'][i - 2]:
@@ -675,6 +680,11 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
         if (pd.isnull(drv_data['Time'][i])
                 or pd.isnull(drv_data['LapTime'][i + 1])):
             # lap not usable, missing critical values; more checks follow
+            continue
+        if pd.isna(drv_data['LapTime'][i]):
+            # LapTime can be NaT for formation laps and other special cases
+            # (e.g., standing restarts after red flags). Skip time adjustment
+            # for this lap since its lap time is not valid.
             continue
 
         if (new_time := drv_data['Time'][i] + drv_data['LapTime'][i+1]) \


### PR DESCRIPTION
## Summary

Fix lap times being set to NaT for drivers during standing restarts after red flags (formation laps).

During the Mexican GP 2023, a Red Flag was displayed on lap 34. Lap 35 began when VER crossed the line and entered the pit lane (formation lap behind SC). Lap 36 began when VER crossed the line and waited on the grid for the race to restart. In lap 36, the LapTime was recorded as NaT for the first 5 drivers (VER, HAM, LEC, SAI, RIC), while other drivers had LapTimes around 2 minutes 20 seconds.

The issue was that the lap synchronization logic in `_laps_data_driver` was attempting to use NaT LapTime values when adjusting lap start times, which corrupted the Time values for subsequent laps.

## Changes

- Added check in `_laps_data_driver` to skip the backward lap time sync adjustment when `LapTime` is NaT
- Added check to skip the forward lap time sync adjustment when `LapTime` (of lap i) is NaT

## Testing

Load Mexico 2023 race session and verify lap times are correct for drivers VER, HAM, LEC, SAI, RIC on lap 36.

## Checklist

- [x] Code follows the project's coding conventions
- [x] Fix addresses the issue described in #473

## AI Disclosure

AI was used as a coding assistant. The human author reviewed all AI-generated code and changes.