### PR TITLE
Fix AttributeError when TeamColour is None in _load_drivers_from_f1_livetiming

### DIFF
--- a/fastf1/plotting/_backend.py
+++ b/fastf1/plotting/_backend.py
@@ -59,7 +59,11 @@ def _load_drivers_from_f1_livetiming(
     for num in sorted(driver_info.keys()):
         driver_entry = driver_info[num]
         team_name = driver_entry.get('TeamName')
-        team_color = f"#{driver_entry.get('TeamColour').lower()}"
+        team_color_raw = driver_entry.get('TeamColour')
+        if team_color_raw is None:
+            team_color = "#000000"
+        else:
+            team_color = f"#{team_color_raw.lower()}"
         abbreviation = driver_entry.get('Tla', '')
         name = ' '.join((driver_entry.get('FirstName', ''),
                          driver_entry.get('LastName', '')))

--- a/fastf1/plotting/_backend.py
+++ b/fastf1/plotting/_backend.py
@@ -25,11 +25,13 @@ for year, consts in json.loads(content).items():
 def _load_drivers_from_f1_livetiming(
         *,
         api_path: str,
-        year: str
+        year: str,
+        driver_info: dict | None = None
 ) -> list[Team]:
 
-    # load the driver information for the determined session
-    driver_info = fastf1._api.driver_info(api_path)
+    if driver_info is None:
+        # load the driver information for the determined session
+        driver_info = fastf1._api.driver_info(api_path)
 
     teams = {}
     if year in Constants:
@@ -59,10 +61,6 @@ def _load_drivers_from_f1_livetiming(
     for num in sorted(driver_info.keys()):
         driver_entry = driver_info[num]
         team_name = driver_entry.get('TeamName')
-        team_color_raw = driver_entry.get('TeamColour')
-        team_color = None
-        if team_color_raw:
-            team_color = f"#{team_color_raw.lower()}"
         abbreviation = driver_entry.get('Tla', '')
         name = ' '.join((driver_entry.get('FirstName', ''),
                          driver_entry.get('LastName', '')))
@@ -80,21 +78,31 @@ def _load_drivers_from_f1_livetiming(
             continue
 
         normalized_full_team_name = _normalize_string(team_name).lower()
-        for normalized_name, team in teams.items():
-            if normalized_name in normalized_full_team_name:
-                team.name = team_name
-                if team_color is not None:
-                    team.colors.official = team_color
-                break
+        team = next(
+            (
+                team
+                for normalized_name, team in teams.items()
+                if normalized_name in normalized_full_team_name
+            ),
+            None
+        )
+        team_color_raw = driver_entry.get('TeamColour')
+        if team_color_raw:
+            team_color = f"#{team_color_raw.lower()}"
+        elif team is not None:
+            team_color = team.colors.official
         else:
-            if team_color is None:
-                _logger.warning(
-                    "Skipping driver with incomplete team color while "
-                    "generating driver-team mapping for plotting constants."
-                )
-                _logger.debug(f"Skipping driver entry: {driver_entry}")
-                continue
+            _logger.warning(
+                "Skipping driver with incomplete team color while "
+                "generating driver-team mapping for plotting constants."
+            )
+            _logger.debug(f"Skipping driver entry: {driver_entry}")
+            continue
 
+        if team is not None:
+            team.name = team_name
+            team.colors.official = team_color
+        else:
             team = _generate_team(team_name, team_color)
 
             _logger.warning(f"Auto-generating unknown team: {team.name}")

--- a/fastf1/plotting/_backend.py
+++ b/fastf1/plotting/_backend.py
@@ -60,15 +60,18 @@ def _load_drivers_from_f1_livetiming(
         driver_entry = driver_info[num]
         team_name = driver_entry.get('TeamName')
         team_color_raw = driver_entry.get('TeamColour')
-        if team_color_raw is None:
-            team_color = "#000000"
-        else:
+        team_color = None
+        if team_color_raw:
             team_color = f"#{team_color_raw.lower()}"
         abbreviation = driver_entry.get('Tla', '')
         name = ' '.join((driver_entry.get('FirstName', ''),
                          driver_entry.get('LastName', '')))
 
-        if not abbreviation.strip() or not name.strip():
+        if (
+            not abbreviation.strip()
+            or not name.strip()
+            or not (team_name and team_name.strip())
+        ):
             _logger.warning(
                 "Skipping driver with incomplete data while generating "
                 "driver-team mapping for plotting constants."
@@ -80,9 +83,18 @@ def _load_drivers_from_f1_livetiming(
         for normalized_name, team in teams.items():
             if normalized_name in normalized_full_team_name:
                 team.name = team_name
-                team.colors.official = team_color
+                if team_color is not None:
+                    team.colors.official = team_color
                 break
         else:
+            if team_color is None:
+                _logger.warning(
+                    "Skipping driver with incomplete team color while "
+                    "generating driver-team mapping for plotting constants."
+                )
+                _logger.debug(f"Skipping driver entry: {driver_entry}")
+                continue
+
             team = _generate_team(team_name, team_color)
 
             _logger.warning(f"Auto-generating unknown team: {team.name}")

--- a/fastf1/tests/test_plotting.py
+++ b/fastf1/tests/test_plotting.py
@@ -2,9 +2,13 @@ import matplotlib.pyplot as plt
 import pytest
 
 import fastf1
+import fastf1._api
 import fastf1.plotting
 from fastf1.exceptions import FuzzyMatchError
-from fastf1.plotting._backend import Constants
+from fastf1.plotting._backend import (
+    Constants,
+    _load_drivers_from_f1_livetiming
+)
 from fastf1.plotting._base import CompoundTypes
 from fastf1.testing import run_in_subprocess
 
@@ -146,6 +150,35 @@ def test_get_team_name_by_driver(identifier, kwargs, expected):
         identifier, session, **kwargs
     )
     assert name == expected
+
+
+def test_load_drivers_preserves_known_team_color_if_live_color_missing(
+        monkeypatch
+):
+    def mock_driver_info(api_path):  # noqa: ARG001
+        return {
+            '16': {
+                'TeamName': 'Ferrari',
+                'TeamColour': None,
+                'Tla': 'LEC',
+                'FirstName': 'Charles',
+                'LastName': 'Leclerc',
+            }
+        }
+
+    monkeypatch.setattr(fastf1._api, 'driver_info', mock_driver_info)
+
+    teams = _load_drivers_from_f1_livetiming(
+        api_path='api/path', year='2026'
+    )
+    team = teams[0]
+
+    assert team.name == 'Ferrari'
+    assert team.normalized_name == 'ferrari'
+    assert team.colors.official == (
+        Constants['2026'].teams['ferrari'].colors.official
+    )
+    assert team.drivers[0].abbreviation == 'LEC'
 
 
 @pytest.mark.parametrize(

--- a/fastf1/tests/test_plotting.py
+++ b/fastf1/tests/test_plotting.py
@@ -2,7 +2,6 @@ import matplotlib.pyplot as plt
 import pytest
 
 import fastf1
-import fastf1._api
 import fastf1.plotting
 from fastf1.exceptions import FuzzyMatchError
 from fastf1.plotting._backend import (
@@ -152,24 +151,19 @@ def test_get_team_name_by_driver(identifier, kwargs, expected):
     assert name == expected
 
 
-def test_load_drivers_preserves_known_team_color_if_live_color_missing(
-        monkeypatch
-):
-    def mock_driver_info(api_path):  # noqa: ARG001
-        return {
-            '16': {
-                'TeamName': 'Ferrari',
-                'TeamColour': None,
-                'Tla': 'LEC',
-                'FirstName': 'Charles',
-                'LastName': 'Leclerc',
-            }
+def test_load_drivers_preserves_known_team_color_if_live_color_missing():
+    driver_info = {
+        '16': {
+            'TeamName': 'Ferrari',
+            'TeamColour': None,
+            'Tla': 'LEC',
+            'FirstName': 'Charles',
+            'LastName': 'Leclerc',
         }
-
-    monkeypatch.setattr(fastf1._api, 'driver_info', mock_driver_info)
+    }
 
     teams = _load_drivers_from_f1_livetiming(
-        api_path='api/path', year='2026'
+        api_path='api/path', year='2026', driver_info=driver_info
     )
     team = teams[0]
 


### PR DESCRIPTION
Fixes #931.

### What changed
- Guard live timing team colors before lowercasing them.
- Preserve built-in official colors for known teams when a session's live timing metadata has `TeamColour=None`.
- Skip only unknown teams that cannot be auto-generated because no team color is available.
- Add a regression test for missing live timing `TeamColour`.

### Why
Some sessions include driver entries with `TeamColour` set to `None`. The previous logic called `.lower()` unconditionally; using `#000000` as a fallback is not desirable because it can produce incorrect plot colors. Known teams already have official color constants, so the missing live value should leave those constants intact.

### Verification
- `.venv/bin/python -m pytest fastf1/tests/test_plotting.py -k "load_drivers_preserves_known_team_color_if_live_color_missing"`
- `.venv/bin/python -m pytest fastf1/tests/test_plotting.py -k "get_team_name_by_driver or load_drivers_preserves_known_team_color_if_live_color_missing"`
- `.venv/bin/python -m ruff check fastf1/plotting/_backend.py`
- `.venv/bin/isort --check-only fastf1/plotting/_backend.py fastf1/tests/test_plotting.py`

### AI Disclosure
AI tools were used to inspect the issue and review feedback, implement the follow-up change, add the regression test, run local validation, and update this PR description. The submitted code changes are in `fastf1/plotting/_backend.py` and `fastf1/tests/test_plotting.py`.
