### PR TITLE
MNT: deprecate round kwarg in Ergast methods (#890)

### DIFF
--- a/docs/changelog/current.rst
+++ b/docs/changelog/current.rst
@@ -11,6 +11,10 @@ Deprecations
   deprecated and will be removed in a future version. Use ``round_number``
   instead. (#890)
 
+- The ``round`` keyword argument is deprecated for all ``Ergast`` data request
+  methods that accept it (e.g. ``get_race_results``, ``get_driver_standings``,
+  ``get_lap_times``). Use ``round_number`` instead. (#890)
+
 What's new in v3.8.3
 --------------------
 

--- a/examples/standings/plot_results_tracker.py
+++ b/examples/standings/plot_results_tracker.py
@@ -23,11 +23,11 @@ for rnd, race in races['raceName'].items():
 
     # Get results. Note that we use the round no. + 1, because the round no.
     # starts from one (1) instead of zero (0)
-    temp = ergast.get_race_results(season=2022, round=rnd + 1)
+    temp = ergast.get_race_results(season=2022, round_number=rnd + 1)
     temp = temp.content[0]
 
     # If there is a sprint, get the results as well
-    sprint = ergast.get_sprint_results(season=2022, round=rnd + 1)
+    sprint = ergast.get_sprint_results(season=2022, round_number=rnd + 1)
     if sprint.content and sprint.description['round'][0] == rnd + 1:
         temp = pd.merge(temp, sprint.content[0], on='driverCode', how='left')
         # Add sprint points and race points to get the total

--- a/examples/standings/plot_who_can_still_win_wdc.py
+++ b/examples/standings/plot_who_can_still_win_wdc.py
@@ -27,7 +27,7 @@ ROUND = 12
 # Reference https://docs.fastf1.dev/ergast.html#fastf1.ergast.Ergast.get_driver_standings
 def get_drivers_standings():
     ergast = Ergast()
-    standings = ergast.get_driver_standings(season=SEASON, round=ROUND)
+    standings = ergast.get_driver_standings(season=SEASON, round_number=ROUND)
     return standings.content[0]
 
 

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -432,7 +432,7 @@ class Ergast:
     def _build_url(
             endpoint: str,
             season: Literal['current'] | int = None,
-            round: Literal['last'] | int = None,
+            round_number: Literal['last'] | int = None,
             circuit: str | None = None,
             constructor: str | None = None,
             driver: str | None = None,
@@ -448,8 +448,8 @@ class Ergast:
 
         if season is not None:
             selectors.append(f"/{season}")
-        if round is not None:
-            selectors.append(f"/{round}")
+        if round_number is not None:
+            selectors.append(f"/{round_number}")
         if grid_position is not None:
             selectors.append(f"/grid/{grid_position}")
         if fastest_rank is not None:
@@ -727,7 +727,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -794,7 +794,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -861,7 +861,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -926,7 +926,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'constructor': constructor,
                      'driver': driver,
                      'grid_position': grid_position,
@@ -992,7 +992,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -1066,7 +1066,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -1134,7 +1134,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -1200,7 +1200,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -1256,7 +1256,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'driver': driver,
                      'standings_position': standings_position}
 
@@ -1309,7 +1309,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'constructor': constructor,
                      'standings_position': standings_position}
 
@@ -1362,7 +1362,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'driver': driver,
                      'lap_number': lap_number}
 
@@ -1416,7 +1416,7 @@ class Ergast:
             ``result_type`` parameter
         """
         selectors = {'season': season,
-                     'round': round,
+                     'round_number': round,
                      'driver': driver,
                      'lap_number': lap_number,
                      'stop_number': stop_number}

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -1537,7 +1537,7 @@ class Ergast:
                       *,
                       round: Literal['last'] | int | None = None
                       ) -> ErgastMultiResponse | ErgastRawResponse:
-        """Get sprint results for one or multiple sprints.
+        """Get lap times for one or multiple sessions.
 
         .. deprecated:: 3.9.0
             The ``round`` keyword argument is deprecated, use

--- a/fastf1/ergast/interface.py
+++ b/fastf1/ergast/interface.py
@@ -682,7 +682,7 @@ class Ergast:
     def get_race_schedule(
             self,
             season: Literal['current'] | int,
-            round: Literal['last'] | int | None = None,
+            round_number: Literal['last'] | int | None = None,
             circuit: str | None = None,
             constructor: str | None = None,
             driver: str | None = None,
@@ -693,9 +693,15 @@ class Ergast:
             result_type: Literal['pandas', 'raw'] | None = None,
             auto_cast: bool | None = None,
             limit: int | None = None,
-            offset: int | None = None
+            offset: int | None = None,
+            *,
+            round: Literal['last'] | int | None = None
     ) -> ErgastSimpleResponse | ErgastRawResponse:
         """Get a list of races.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/schedule/
 
@@ -704,7 +710,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             circuit: select a circuit by its circuit id (default: all)
             constructor: select a constructor by its constructor id
                 (default: all)
@@ -726,8 +732,22 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -749,7 +769,7 @@ class Ergast:
     def get_driver_info(
             self,
             season: Literal['current'] | int | None = None,
-            round: Literal['last'] | int | None = None,
+            round_number: Literal['last'] | int | None = None,
             circuit: str | None = None,
             constructor: str | None = None,
             driver: str | None = None,
@@ -760,9 +780,15 @@ class Ergast:
             result_type: Literal['pandas', 'raw'] | None = None,
             auto_cast: bool | None = None,
             limit: int | None = None,
-            offset: int | None = None
+            offset: int | None = None,
+            *,
+            round: Literal['last'] | int | None = None
     ) -> ErgastSimpleResponse | ErgastRawResponse:
         """Get a list of drivers.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/drivers/
 
@@ -771,7 +797,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             circuit: select a circuit by its circuit id (default: all)
             constructor: select a constructor by its constructor id
                 (default: all)
@@ -793,8 +819,22 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -816,7 +856,7 @@ class Ergast:
     def get_constructor_info(
             self,
             season: Literal['current'] | int | None = None,
-            round: Literal['last'] | int | None = None,
+            round_number: Literal['last'] | int | None = None,
             circuit: str | None = None,
             constructor: str | None = None,
             driver: str | None = None,
@@ -827,9 +867,15 @@ class Ergast:
             result_type: Literal['pandas', 'raw'] | None = None,
             auto_cast: bool | None = None,
             limit: int | None = None,
-            offset: int | None = None
+            offset: int | None = None,
+            *,
+            round: Literal['last'] | int | None = None
     ) -> ErgastSimpleResponse | ErgastRawResponse:
         """Get a list of constructors.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/constructors/
 
@@ -838,7 +884,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             circuit: select a circuit by its circuit id (default: all)
             constructor: select a constructor by its constructor id
                 (default: all)
@@ -860,8 +906,22 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -883,7 +943,7 @@ class Ergast:
     def get_circuits(
             self,
             season: Literal['current'] | int | None = None,
-            round: Literal['last'] | int | None = None,
+            round_number: Literal['last'] | int | None = None,
             constructor: str | None = None,
             driver: str | None = None,
             grid_position: int | None = None,
@@ -893,9 +953,15 @@ class Ergast:
             result_type: Literal['pandas', 'raw'] | None = None,
             auto_cast: bool | None = None,
             limit: int | None = None,
-            offset: int | None = None
+            offset: int | None = None,
+            *,
+            round: Literal['last'] | int | None = None
     ) -> ErgastSimpleResponse | ErgastRawResponse:
         """Get a list of circuits.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/circuits/
 
@@ -904,7 +970,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             constructor: select a constructor by its constructor id
                 (default: all)
             driver: select a driver by its driver id (default: all)
@@ -925,8 +991,22 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'constructor': constructor,
                      'driver': driver,
                      'grid_position': grid_position,
@@ -947,7 +1027,7 @@ class Ergast:
     def get_finishing_status(
             self,
             season: Literal['current'] | int | None = None,
-            round: Literal['last'] | int | None = None,
+            round_number: Literal['last'] | int | None = None,
             circuit: str | None = None,
             constructor: str | None = None,
             driver: str | None = None,
@@ -958,9 +1038,15 @@ class Ergast:
             result_type: Literal['pandas', 'raw'] | None = None,
             auto_cast: bool | None = None,
             limit: int | None = None,
-            offset: int | None = None
+            offset: int | None = None,
+            *,
+            round: Literal['last'] | int | None = None
     ) -> ErgastSimpleResponse | ErgastRawResponse:
         """Get a list of finishing status codes.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/status/
 
@@ -969,7 +1055,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             circuit: select a circuit by its circuit id (default: all)
             constructor: select a constructor by its constructor id
                 (default: all)
@@ -991,8 +1077,22 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -1020,7 +1120,7 @@ class Ergast:
     def get_race_results(
             self,
             season: Literal['current'] | int | None = None,
-            round: Literal['last'] | int | None = None,
+            round_number: Literal['last'] | int | None = None,
             circuit: str | None = None,
             constructor: str | None = None,
             driver: str | None = None,
@@ -1031,9 +1131,15 @@ class Ergast:
             result_type: Literal['pandas', 'raw'] | None = None,
             auto_cast: bool | None = None,
             limit: int | None = None,
-            offset: int | None = None
+            offset: int | None = None,
+            *,
+            round: Literal['last'] | int | None = None
     ) -> ErgastMultiResponse | ErgastRawResponse:
         """Get race results for one or multiple races.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/results/
 
@@ -1043,7 +1149,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             circuit: select a circuit by its circuit id (default: all)
             constructor: select a constructor by its constructor id
                 (default: all)
@@ -1065,8 +1171,22 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -1088,7 +1208,7 @@ class Ergast:
     def get_qualifying_results(
             self,
             season: Literal['current'] | int | None = None,
-            round: Literal['last'] | int | None = None,
+            round_number: Literal['last'] | int | None = None,
             circuit: str | None = None,
             constructor: str | None = None,
             driver: str | None = None,
@@ -1099,9 +1219,15 @@ class Ergast:
             result_type: Literal['pandas', 'raw'] | None = None,
             auto_cast: bool | None = None,
             limit: int | None = None,
-            offset: int | None = None
+            offset: int | None = None,
+            *,
+            round: Literal['last'] | int | None = None
     ) -> ErgastMultiResponse | ErgastRawResponse:
         """Get qualifying results for one or multiple qualifying sessions.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/qualifying/
 
@@ -1111,7 +1237,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             circuit: select a circuit by its circuit id (default: all)
             constructor: select a constructor by its constructor id
                 (default: all)
@@ -1133,8 +1259,22 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -1156,7 +1296,7 @@ class Ergast:
     def get_sprint_results(
             self,
             season: Literal['current'] | int | None = None,
-            round: Literal['last'] | int | None = None,
+            round_number: Literal['last'] | int | None = None,
             circuit: str | None = None,
             constructor: str | None = None,
             driver: str | None = None,
@@ -1166,9 +1306,15 @@ class Ergast:
             result_type: Literal['pandas', 'raw'] | None = None,
             auto_cast: bool | None = None,
             limit: int | None = None,
-            offset: int | None = None
+            offset: int | None = None,
+            *,
+            round: Literal['last'] | int | None = None
     ) -> ErgastMultiResponse | ErgastRawResponse:
         """Get sprint results for one or multiple sprints.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/sprint/
 
@@ -1178,7 +1324,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             circuit: select a circuit by its circuit id (default: all)
             constructor: select a constructor by its constructor id
                 (default: all)
@@ -1199,8 +1345,22 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'circuit': circuit,
                      'constructor': constructor,
                      'driver': driver,
@@ -1221,15 +1381,21 @@ class Ergast:
     def get_driver_standings(
             self,
             season: Literal['current'] | int | None = None,
-            round: Literal['last'] | int | None = None,
+            round_number: Literal['last'] | int | None = None,
             driver: str | None = None,
             standings_position: int | None = None,
             result_type: Literal['pandas', 'raw'] | None = None,
             auto_cast: bool | None = None,
             limit: int | None = None,
-            offset: int | None = None
+            offset: int | None = None,
+            *,
+            round: Literal['last'] | int | None = None
     ) -> ErgastMultiResponse | ErgastRawResponse:
         """Get driver standings at specific points of a season.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/standings/
 
@@ -1239,7 +1405,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             driver: select a driver by its driver id (default: all)
             standings_position: select a result by position in the standings
                 (default: all)
@@ -1255,8 +1421,22 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'driver': driver,
                      'standings_position': standings_position}
 
@@ -1273,15 +1453,21 @@ class Ergast:
     def get_constructor_standings(
             self,
             season: Literal['current'] | int | None = None,
-            round: Literal['last'] | int | None = None,
+            round_number: Literal['last'] | int | None = None,
             constructor: str | None = None,
             standings_position: int | None = None,
             result_type: Literal['pandas', 'raw'] | None = None,
             auto_cast: bool | None = None,
             limit: int | None = None,
-            offset: int | None = None
+            offset: int | None = None,
+            *,
+            round: Literal['last'] | int | None = None
     ) -> ErgastMultiResponse | ErgastRawResponse:
         """Get constructor standings at specific points of a season.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/standings/
 
@@ -1291,7 +1477,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             constructor: select a constructor by its constructor id
                 (default: all)
             standings_position: select a result by position in the standings
@@ -1308,8 +1494,22 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'constructor': constructor,
                      'standings_position': standings_position}
 
@@ -1327,15 +1527,21 @@ class Ergast:
 
     def get_lap_times(self,
                       season: Literal['current'] | int,
-                      round: Literal['last'] | int,
+                      round_number: Literal['last'] | int | None = None,
                       lap_number: int | None = None,
                       driver: str | None = None,
                       result_type: Literal['pandas', 'raw'] | None = None,
                       auto_cast: bool | None = None,
                       limit: int | None = None,
-                      offset: int | None = None
+                      offset: int | None = None,
+                      *,
+                      round: Literal['last'] | int | None = None
                       ) -> ErgastMultiResponse | ErgastRawResponse:
         """Get sprint results for one or multiple sprints.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/laps/
 
@@ -1345,7 +1551,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             lap_number: select lap times by a specific lap number
                 (default: all)
             driver: select a driver by its driver id (default: all)
@@ -1361,8 +1567,27 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
+        if round_number is None:
+            raise ValueError(
+                "get_lap_times() missing 1 required argument: 'round_number'"
+            )
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'driver': driver,
                      'lap_number': lap_number}
 
@@ -1378,16 +1603,22 @@ class Ergast:
 
     def get_pit_stops(self,
                       season: Literal['current'] | int,
-                      round: Literal['last'] | int,
+                      round_number: Literal['last'] | int | None = None,
                       stop_number: int | None = None,
                       lap_number: int | None = None,
                       driver: str | None = None,
                       result_type: Literal['pandas', 'raw'] | None = None,
                       auto_cast: bool | None = None,
                       limit: int | None = None,
-                      offset: int | None = None
+                      offset: int | None = None,
+                      *,
+                      round: Literal['last'] | int | None = None
                       ) -> ErgastMultiResponse | ErgastRawResponse:
         """Get pit stop information for one or multiple sessions.
+
+        .. deprecated:: 3.9.0
+            The ``round`` keyword argument is deprecated, use
+            ``round_number`` instead.
 
         See: https://ergast.com/mrd/methods/standings/
 
@@ -1397,7 +1628,7 @@ class Ergast:
 
         Args:
             season: select a season by its year (default: all, oldest first)
-            round: select a round by its number (default: all)
+            round_number: select a round by its number (default: all)
             lap_number: select pit stops by a specific lap number
                 (default: all)
             stop_number: select pit stops by their stop number
@@ -1415,8 +1646,27 @@ class Ergast:
             :class:`~interface.ErgastRawResponse`, depending on the
             ``result_type`` parameter
         """
+        if round is not None:
+            warnings.warn(
+                "The `round` keyword argument is deprecated and will be "
+                "removed in a future version. Use `round_number` instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            if round_number is not None:
+                raise ValueError(
+                    "Cannot pass both `round_number` and `round`. "
+                    "Use `round_number` only; `round` is deprecated."
+                )
+            round_number = round
+
+        if round_number is None:
+            raise ValueError(
+                "get_pit_stops() missing 1 required argument: 'round_number'"
+            )
+
         selectors = {'season': season,
-                     'round_number': round,
+                     'round_number': round_number,
                      'driver': driver,
                      'lap_number': lap_number,
                      'stop_number': stop_number}

--- a/fastf1/tests/test_core.py
+++ b/fastf1/tests/test_core.py
@@ -20,7 +20,7 @@ def test_lap_data_loading_position_calculation():
 
     ergast = Ergast()
     ergast_laps = ergast.get_lap_times(
-        season=2023, round=1, limit=20 * 60
+        season=2023, round_number=1, limit=20 * 60
     ).content[0]
     ergast_drivers = ergast.get_driver_info(season=2023)
 

--- a/fastf1/tests/test_ergast.py
+++ b/fastf1/tests/test_ergast.py
@@ -343,13 +343,13 @@ def test_merge_dicts_of_lists(data, expected):
         ['races', {'season': 2022},
          f"{BASE_URL}/2022/races.json"],
 
-        ['results', {'season': 2022, 'round': '10'},
+        ['results', {'season': 2022, 'round_number': '10'},
          f"{BASE_URL}/2022/10/results.json"],
 
-        ['sprint', {'season': 2022, 'round': '4'},
+        ['sprint', {'season': 2022, 'round_number': '4'},
          f"{BASE_URL}/2022/4/sprint.json"],
 
-        ['qualifying', {'season': 2022, 'round': '10'},
+        ['qualifying', {'season': 2022, 'round_number': '10'},
          f"{BASE_URL}/2022/10/qualifying.json"],
 
         # special cases where endpoint name matches selector and the endpoint
@@ -390,20 +390,20 @@ def test_merge_dicts_of_lists(data, expected):
         ['constructorStandings', {'season': 2022, 'standings_position': '1'},
          f"{BASE_URL}/2022/constructorStandings/1.json"],
 
-        ['laps', {'season': 2022, 'round': 10},
+        ['laps', {'season': 2022, 'round_number': 10},
          f"{BASE_URL}/2022/10/laps.json"],
 
-        ['laps', {'season': 2022, 'round': 10, 'lap_number': 1},
+        ['laps', {'season': 2022, 'round_number': 10, 'lap_number': 1},
          f"{BASE_URL}/2022/10/laps/1.json"],
 
-        ['pitstops', {'season': 2022, 'round': 10},
+        ['pitstops', {'season': 2022, 'round_number': 10},
          f"{BASE_URL}/2022/10/pitstops.json"],
 
-        ['pitstops', {'season': 2022, 'round': 10, 'stop_number': '1'},
+        ['pitstops', {'season': 2022, 'round_number': 10, 'stop_number': '1'},
          f"{BASE_URL}/2022/10/pitstops/1.json"],
 
         # endpoint/selector combination in other request
-        ['pitstops', {'season': 2022, 'round': 10, 'lap_number': 1},
+        ['pitstops', {'season': 2022, 'round_number': 10, 'lap_number': 1},
          f"{BASE_URL}/2022/10/laps/1/pitstops.json"],
 
         ['circuits', {'driver': 'alonso', 'constructor': 'alpine'},
@@ -426,7 +426,7 @@ def test_ergast_response_mixin():
                       'subcategory': API.RaceResults,
                       'result_type': 'raw', 'auto_cast': False}
 
-    selectors = {'season': 2022, 'round': None, 'circuit': None,
+    selectors = {'season': 2022, 'round_number': None, 'circuit': None,
                  'constructor': None, 'driver': None, 'grid_position': None,
                  'fastest_rank': None, 'status': None}
 

--- a/fastf1/tests/test_ergast.py
+++ b/fastf1/tests/test_ergast.py
@@ -752,3 +752,43 @@ def test_ergast_api_endpoints_multi_response():
     assert result.content[0].shape[1] == 26  # correct dataframe shape
     assert 'fastestLapTime' in result.content[0].columns  # columns renamed
     assert result.content[0]['fastestLapTime'].dtype == '<m8[ns]'  # casting
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ('get_race_schedule', 'get_driver_info', 'get_constructor_info',
+     'get_circuits', 'get_finishing_status', 'get_race_results',
+     'get_qualifying_results', 'get_sprint_results', 'get_driver_standings',
+     'get_constructor_standings', 'get_lap_times', 'get_pit_stops')
+)
+def test_ergast_round_deprecated_kwarg(method_name):
+    # capture the selectors instead of making an actual request
+    class ErgastTest(Ergast):
+        test_build_args = {}
+
+        def _build_default_result(self, **kwargs):
+            ErgastTest.test_build_args = kwargs
+
+    method = getattr(ErgastTest(), method_name)
+
+    # Deprecated `round` kwarg still works but emits FutureWarning
+    with pytest.warns(FutureWarning, match="deprecated"):
+        method(2022, round=2)
+    assert ErgastTest.test_build_args['selectors']['round_number'] == 2
+    # Passing both raises ValueError (and emits the warning first)
+    with (
+        pytest.warns(FutureWarning, match="deprecated"),
+        pytest.raises(ValueError, match="Cannot pass both"),
+    ):
+        method(2022, round_number=2, round=2)
+
+
+@pytest.mark.parametrize("method_name", ('get_lap_times', 'get_pit_stops'))
+def test_ergast_round_required_kwarg(method_name):
+    # `round` is mandatory for these methods; passing neither raises before
+    # any request is made
+    method = getattr(Ergast(), method_name)
+
+    # Passing neither raises ValueError
+    with pytest.raises(ValueError, match="missing 1 required argument"):
+        method(2022)


### PR DESCRIPTION
Follow-up to #920 (the get_event_by_round pilot). Applies the same
round -> round_number deprecation to the Ergast data request methods.
Part of #890.

Changes:
- ergast/interface.py:
  - _build_url (private): renamed round -> round_number. Just a rename,
    it's internal with no external callers.
  - the 12 public get_* methods: added round_number, kept round as a
    deprecated keyword-only alias that emits a FutureWarning, and raise
    ValueError if both are passed. get_lap_times / get_pit_stops also
    raise ValueError if neither is passed (round was required there).
- test_ergast.py: parametrized tests for the deprecated path, the
  both passed case, and the neither passed case. Mocked so they don't
  hit the API.
- test_core.py and the two examples/standings scripts: switched their
  round= calls to round_number= so they don't trip the new warning.
- changelog: Deprecations entry under v3.9.0.
- Also fixed `get_lap_times' docstring summary, which was copy-pasted from
get_sprint_results.

Left pyproject.toml / the A002 rule out of this on purpose

AI disclosure: used Claude for navigating the codebase and grammar review on this PR description. All code typed and reviewed by me.