### PR TITLE
Enable Ruff Q rules in docs and config files

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -70,7 +70,7 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip_ergast)
 
     # only test documentation and project structure
-    if config.getoption('--prj-doc'):
+    if config.getoption("--prj-doc"):
         skip_non_prj = pytest.mark.skip(reason="--prj-doc given: run only "
                                                "project structure and "
                                                "documentation tests")
@@ -90,30 +90,30 @@ def pytest_collection_modifyitems(config, items):
 def pytest_report_teststatus(report, config):  # noqa: ARG001
     from fastf1 import Cache
 
-    if (report.when == 'teardown') and (Cache._request_counter > 0):
-        name = report.location[0] + '::' + report.location[2]
+    if (report.when == "teardown") and (Cache._request_counter > 0):
+        name = report.location[0] + "::" + report.location[2]
         line = (
             f"{name} - uncached requests:\t"
             f"{Cache._request_counter}"
         )
-        report.sections.append(('Request Count', line))
+        report.sections.append(("Request Count", line))
         Cache._request_counter = 0
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):  # noqa: ARG001
-    reports = terminalreporter.getreports('')
+    reports = terminalreporter.getreports("")
     content = os.linesep.join(
         text for report in reports for secname, text in report.sections
-        if secname == 'Request Count'
+        if secname == "Request Count"
     )
     if content:
         terminalreporter.ensure_newline()
-        terminalreporter.section('Request count', sep='-', blue=True,
+        terminalreporter.section("Request count", sep="-", blue=True,
                                  bold=True)
         terminalreporter.line(content)
 
     terminalreporter.ensure_newline()
-    terminalreporter.section('Parameter Overrides', sep='-', blue=True,
+    terminalreporter.section("Parameter Overrides", sep="-", blue=True,
                              bold=True)
     terminalreporter.line(f"Ergast backend override: "
                           f"{ERGAST_BACKEND_OVERRIDE}")
@@ -127,7 +127,7 @@ def reference_laps_data():
     # require it
     import fastf1
     fastf1.Cache.enable_cache("test_cache/")
-    session = fastf1.get_session(2020, 'Italy', 'R')
+    session = fastf1.get_session(2020, "Italy", "R")
     session.load()
     return session, session.laps
 
@@ -138,11 +138,11 @@ def fastf1_setup():
     from fastf1.logger import LoggingManager
 
     try:
-        fastf1.Cache.enable_cache('test_cache')  # use specific cache directory
+        fastf1.Cache.enable_cache("test_cache")  # use specific cache directory
     except NotADirectoryError:
         # create the test cache and re-enable
-        os.mkdir('test_cache')
-        fastf1.Cache.enable_cache('test_cache')
+        os.mkdir("test_cache")
+        fastf1.Cache.enable_cache("test_cache")
 
     fastf1.Cache.ci_mode(True)  # only request uncached data
     LoggingManager.debug = True  # raise all exceptions

--- a/docs/_plots/colormap_overview.py
+++ b/docs/_plots/colormap_overview.py
@@ -38,7 +38,7 @@ for i, year in enumerate(years_sorted):
     # configure y axis and label
     ax.set_ylim((0.5, 2.5))
     ax.set_yticks([1, 2])
-    ax.set_yticklabels(['official', 'default'])
+    ax.set_yticklabels(["official", "default"])
 
     # configure x axis and label
     ax.set_xlim((0.5, len(x_ranges) + 0.5))
@@ -46,10 +46,10 @@ for i, year in enumerate(years_sorted):
     ax.set_xticklabels(x_labels)
 
     # disable frame around axis
-    ax.spines['top'].set_visible(False)
-    ax.spines['bottom'].set_visible(False)
-    ax.spines['right'].set_visible(False)
-    ax.spines['left'].set_visible(False)
+    ax.spines["top"].set_visible(False)
+    ax.spines["bottom"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_visible(False)
 
     # disable tick markers everywhere, label x axis at the top
     ax.tick_params(top=False, labeltop=True, bottom=False, labelbottom=False,
@@ -57,19 +57,19 @@ for i, year in enumerate(years_sorted):
 
     # set tick label text color (grey, so it works on light and dark theme and
     # isn't too distracting next to the colors)
-    ax.tick_params(colors='#787878')
+    ax.tick_params(colors="#787878")
 
     # set background color within axes
     # (transparent, fallback white if transparency not supported)
-    ax.set_facecolor('#ffffff00')
+    ax.set_facecolor("#ffffff00")
 
     # set axes title (grey, so it works on light and dark theme and
     # isn't too distracting next to the colors)
-    ax.set_title(year, color='#787878')
+    ax.set_title(year, color="#787878")
 
 # set background color for figure/margins around axes
 # (transparent, fallback white if transparency not supported)
-fig.patch.set_facecolor('#ffffff00')
+fig.patch.set_facecolor("#ffffff00")
 
 # adjust margins between and around axes
 plt.subplots_adjust(top=0.95, bottom=0.05, left=0.1, right=0.95, hspace=0.5)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ from plotly.io._sg_scraper import plotly_sg_scraper
 import fastf1
 
 
-sys.path.append(os.path.abspath('extensions'))
+sys.path.append(os.path.abspath("extensions"))
 
 
 ERGAST_BACKEND_OVERRIDE = os.environ.get("FASTF1_DOCS_ERGAST_BACKEND_OVERRIDE")
@@ -34,34 +34,34 @@ if ERGAST_BACKEND_OVERRIDE:
 
 # -- FastF1 specific config --------------------------------------------------
 # ignore warning on import of fastf1.api
-warnings.filterwarnings(action='ignore',
-                        message=r'`fastf1.api` will be considered private .*')
-warnings.filterwarnings(action='ignore',
-                        message=r'`utils.delta_time` is considered '
-                                r'deprecated.*')
-warnings.filterwarnings(action='ignore',
-                        message=r'(COMPOUND_COLORS|DRIVER_COLORS|'
-                                r'DRIVER_TRANSLATE|TEAM_COLORS|TEAM_TRANSLATE|'
-                                r'COLOR_PALETTE) is deprecated and.*')
+warnings.filterwarnings(action="ignore",
+                        message=r"`fastf1.api` will be considered private .*")
+warnings.filterwarnings(action="ignore",
+                        message=r"`utils.delta_time` is considered "
+                                r"deprecated.*")
+warnings.filterwarnings(action="ignore",
+                        message=r"(COMPOUND_COLORS|DRIVER_COLORS|"
+                                r"DRIVER_TRANSLATE|TEAM_COLORS|TEAM_TRANSLATE|"
+                                r"COLOR_PALETTE) is deprecated and.*")
 
-doc_cache = os.path.abspath('../doc_cache')
+doc_cache = os.path.abspath("../doc_cache")
 if not os.path.exists(doc_cache):
     os.makedirs(doc_cache)
 
 # -- Project information -----------------------------------------------------
 
-project = 'FastF1'
+project = "FastF1"
 # copyright = 'MIT'
 # author = 'Oehrly'
 version = fastf1.__version__
 release = version
-copyright = f'{datetime.now().year}, Philipp Schäfer'  # noqa: A001
+copyright = f"{datetime.now().year}, Philipp Schäfer"  # noqa: A001
 html_title = f"{project} ({release})"
 
-with open(os.path.abspath('../pyproject.toml'), 'rb') as f:
+with open(os.path.abspath("../pyproject.toml"), "rb") as f:
     pyproject = tomllib.load(f)
 
-python_requires = pyproject['project']['requires-python']
+python_requires = pyproject["project"]["requires-python"]
 min_python_version = python_requires.removeprefix(">=")
 
 rst_epilog = f"""
@@ -74,26 +74,26 @@ rst_epilog = f"""
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'matplotlib.sphinxext.plot_directive',
-    'sphinx.ext.doctest',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinx_autodoc_typehints',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
-    'sphinx_gallery.gen_gallery',
-    'autodocsumm',
-    'fastf1.ergast.sphinx',
-    'nitpick_ignore_files',
-    'notfound.extension',
+    "matplotlib.sphinxext.plot_directive",
+    "sphinx.ext.doctest",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx_autodoc_typehints",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
+    "sphinx_gallery.gen_gallery",
+    "autodocsumm",
+    "fastf1.ergast.sphinx",
+    "nitpick_ignore_files",
+    "notfound.extension",
 ]
 
 todo_include_todos = True
-autodoc_member_order = 'bysource'
+autodoc_member_order = "bysource"
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -103,21 +103,21 @@ exclude_patterns = []
 nitpicky = True
 
 nitpick_ignore_regex = [
-    (r'py:class', r'collections.abc\..*'),
-    (r'py:data', r'typing\..*'),
-    (r'py:.*', r'datetime\..*'),
-    (r'py:.*', r'pandas\..*'),
-    (r'py:.*', r'pd\..*'),
-    (r'py:.*', r'numpy\..*'),
-    (r'py:.*', r'matplotlib\..*'),
-    (r'py:mod', r'logging'),
-    (r'py:class', r'logging.Logger'),
+    (r"py:class", r"collections.abc\..*"),
+    (r"py:data", r"typing\..*"),
+    (r"py:.*", r"datetime\..*"),
+    (r"py:.*", r"pandas\..*"),
+    (r"py:.*", r"pd\..*"),
+    (r"py:.*", r"numpy\..*"),
+    (r"py:.*", r"matplotlib\..*"),
+    (r"py:mod", r"logging"),
+    (r"py:class", r"logging.Logger"),
 ]
 
 nitpick_ignore_files = [
     # exclude changelog from nitpick, old entries might reference removed
     # functionality
-    r'changelog/.*',
+    r"changelog/.*",
 ]
 # nitpick_ignore_files is a custom extension (docs/extensions)
 
@@ -157,21 +157,21 @@ html_favicon = "_static/favicon.png"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files that should be copied to the
 # output directory.
-html_extra_path = ['_extra']
+html_extra_path = ["_extra"]
 
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
 html_css_files = [
-    'css/custom.css',
+    "css/custom.css",
 ]
 
 # -- Plotly configuration ----------------------------------------------------
 # use sphinx to render plotly
-pio.renderers.default = 'sphinx_gallery_png'
+pio.renderers.default = "sphinx_gallery_png"
 
 
 # -- matplotlib plot directive options ---------------------------------------
@@ -203,32 +203,32 @@ def sphinx_gallery_setup(gallery_conf, fname):  # noqa: ARG001
     import fastf1
     import fastf1.logger
     fastf1.Cache.enable_cache(doc_cache)
-    fastf1.logger.set_log_level('WARNING')
+    fastf1.logger.set_log_level("WARNING")
 
 
 sphinx_gallery_conf = {
-    'examples_dirs': '../examples',
-    'gallery_dirs': 'gen_modules/examples_gallery',
-    'download_all_examples': False,
-    'remove_config_comments': True,
-    'image_scrapers': ('matplotlib',  # default
+    "examples_dirs": "../examples",
+    "gallery_dirs": "gen_modules/examples_gallery",
+    "download_all_examples": False,
+    "remove_config_comments": True,
+    "image_scrapers": ("matplotlib",  # default
                        plotly_sg_scraper),  # for plotly thumbnail
-    'reset_modules': ('matplotlib', 'seaborn',  # defaults
+    "reset_modules": ("matplotlib", "seaborn",  # defaults
                       sphinx_gallery_setup),  # custom setup
     # directory where function/class granular galleries are stored
-    'backreferences_dir': 'gen_modules/backreferences',
+    "backreferences_dir": "gen_modules/backreferences",
 
     # if an example does not produce an output plot, use the following image
     # as the thumbnail.
-    'default_thumb_file': '_static/logo.png',
+    "default_thumb_file": "_static/logo.png",
 
     # Modules for which function/class level galleries are created. In
     # this case sphinx_gallery and numpy in a tuple of strings.
-    'doc_module': ('fastf1', ),
+    "doc_module": ("fastf1", ),
 }
 
 
 # -- options for latexpdf build ----------------------------------------------
 latex_elements = {
-    'preamble': r'\usepackage{enumitem}\setlistdepth{99}',
+    "preamble": r"\usepackage{enumitem}\setlistdepth{99}",
 }

--- a/docs/extensions/nitpick_ignore_files.py
+++ b/docs/extensions/nitpick_ignore_files.py
@@ -14,9 +14,9 @@ class NitpickIgnoreFiles(logging.Filter):
         super().__init__()
 
     def filter(self, record: sphinx_logging.SphinxLogRecord) -> bool:
-        if getattr(record, 'type', None) == 'ref':
+        if getattr(record, "type", None) == "ref":
             for pattern in self.app.config.nitpick_ignore_files:
-                if re.match(pattern, record.location.get('refdoc')):
+                if re.match(pattern, record.location.get("refdoc")):
                     return False
             return True
 
@@ -24,8 +24,8 @@ class NitpickIgnoreFiles(logging.Filter):
 
 
 def setup(app: Sphinx):
-    app.add_config_value('nitpick_ignore_files', [], '')
+    app.add_config_value("nitpick_ignore_files", [], "")
     f = NitpickIgnoreFiles(app)
     sphinx_logging \
-        .getLogger('sphinx.transforms.post_transforms') \
+        .getLogger("sphinx.transforms.post_transforms") \
         .logger.addFilter(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ select = [
     "PERF",
     "ARG",
     "RUF100",
+    "Q",
 ]
 
 ignore = [


### PR DESCRIPTION
## Summary

Enable Ruff Q rules for quote consistency in documentation and config files.

## Changes

Automated quote fixes across docs/ and conftest.py, plus the Ruff Q rule enablement in pyproject.toml.

## AI Disclosure

AI was used as a coding assistant. The human author reviewed all AI-generated code and changes.