### PR TITLE
fix(plotting): guard against missing team colour in live timing data (#931)

### DIFF
--- a/fastf1/plotting/_backend.py
+++ b/fastf1/plotting/_backend.py
@@ -22,6 +22,11 @@ for year, consts in json.loads(content).items():
     Constants[year] = SeasonConstants(**consts)
 
 
+# fallback colour used when a live timing driver entry is missing the team
+# colour (e.g. incomplete live timing metadata); see GH #931
+_DEFAULT_TEAM_COLOR = "#808080"
+
+
 def _load_drivers_from_f1_livetiming(
         *,
         api_path: str,
@@ -59,7 +64,10 @@ def _load_drivers_from_f1_livetiming(
     for num in sorted(driver_info.keys()):
         driver_entry = driver_info[num]
         team_name = driver_entry.get("TeamName")
-        team_color = f"#{driver_entry.get('TeamColour').lower()}"
+        # live timing data can be incomplete and miss the team colour; guard
+        # against ``None`` here to avoid an ``AttributeError`` (GH #931)
+        team_colour = driver_entry.get("TeamColour")
+        team_color = f"#{team_colour.lower()}" if team_colour else None
         abbreviation = driver_entry.get("Tla", "")
         name = " ".join((driver_entry.get("FirstName", ""),
                          driver_entry.get("LastName", "")))
@@ -76,10 +84,14 @@ def _load_drivers_from_f1_livetiming(
         for normalized_name, team in teams.items():
             if normalized_name in normalized_full_team_name:
                 team.name = team_name
-                team.colors.official = team_color
+                # keep the built-in colour if live timing did not provide one
+                if team_color is not None:
+                    team.colors.official = team_color
                 break
         else:
-            team = _generate_team(team_name, team_color)
+            team = _generate_team(
+                team_name, team_color or _DEFAULT_TEAM_COLOR
+            )
 
             _logger.warning(f"Auto-generating unknown team: {team.name}")
 

--- a/fastf1/tests/test_plotting.py
+++ b/fastf1/tests/test_plotting.py
@@ -2,9 +2,14 @@ import matplotlib.pyplot as plt
 import pytest
 
 import fastf1
+import fastf1._api
 import fastf1.plotting
 from fastf1.exceptions import FuzzyMatchError
-from fastf1.plotting._backend import Constants
+from fastf1.plotting._backend import (
+    _DEFAULT_TEAM_COLOR,
+    _load_drivers_from_f1_livetiming,
+    Constants
+)
 from fastf1.plotting._base import CompoundTypes
 from fastf1.testing import run_in_subprocess
 
@@ -523,6 +528,48 @@ def test_override_team_constants():
 
     if fastf1.plotting.get_team_name('Haas', session, short=True) != 'Haas':
         raise RuntimeError("Test cleanup failed!")
+
+
+def test_load_drivers_missing_team_colour(monkeypatch):
+    # regression test for GH #931: live timing driver entries can have
+    # ``TeamColour=None`` (incomplete live timing metadata), which previously
+    # raised an ``AttributeError`` while building the driver-team mapping
+    fake_driver_info = {
+        "1": {  # known team with a valid colour
+            "TeamName": "Mercedes",
+            "TeamColour": "27F4D2",
+            "Tla": "HAM",
+            "FirstName": "Lewis",
+            "LastName": "Hamilton",
+        },
+        "2": {  # known team, missing colour -> must not crash or overwrite
+            "TeamName": "Mercedes",
+            "TeamColour": None,
+            "Tla": "RUS",
+            "FirstName": "George",
+            "LastName": "Russell",
+        },
+        "3": {  # unknown team, missing colour -> falls back to default colour
+            "TeamName": "Quux Motorsport",
+            "TeamColour": None,
+            "Tla": "QUX",
+            "FirstName": "Quux",
+            "LastName": "Driver",
+        },
+    }
+    monkeypatch.setattr(
+        fastf1._api, "driver_info", lambda api_path: fake_driver_info
+    )
+
+    teams = _load_drivers_from_f1_livetiming(api_path="/fake", year="2023")
+    by_name = {team.normalized_name: team for team in teams}
+
+    # the missing colour for the second Mercedes driver must neither raise nor
+    # overwrite the colour supplied by the first driver
+    assert by_name["mercedes"].colors.official == "#27f4d2"
+
+    # an unknown team with no colour falls back to the default team colour
+    assert by_name["quux motorsport"].colors.official == _DEFAULT_TEAM_COLOR
 
 
 def test_import_internal_mpl_lgend_arg_kwarg_parser():


### PR DESCRIPTION
Closes #931.

`_load_drivers_from_f1_livetiming` called `.lower()` directly on the `TeamColour` field, raising `AttributeError` when live timing returns `None` for it (reproduced on 2026 round 5 FP1).

This guards against a missing colour:
- **known teams keep their built-in colour** instead of being overwritten with a fallback
- **unknown auto-generated teams** fall back to a neutral default colour (`#808080`)

Added a regression test that builds the mapping from mocked live timing data containing a `None` colour. Existing plotting tests still pass; `ruff` is clean on the changed module.