### PR TITLE
MNT: Address upcoming numpy deprecation for ``np.timedelta64``

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1469,7 +1469,7 @@ class Session:
         # remove first lap pitout time if it is before session_start_time
         mask = (data["PitOutTime"] < self.session_start_time) & \
                (data["NumberOfLaps"] == 1)
-        data.loc[mask, "PitOutTime"] = np.timedelta64("NaT")
+        data.loc[mask, "PitOutTime"] = np.timedelta64("NaT", "ns")
 
         drivers = self.drivers
         if not drivers:
@@ -1552,7 +1552,7 @@ class Session:
                 # started can only be made for the race
                 laps_start_time.insert(0, self.session_start_time)
             else:
-                laps_start_time.insert(0, np.timedelta64("NaT"))
+                laps_start_time.insert(0, np.timedelta64("NaT", "ns"))
 
             # don't set lap start times after red flag restart to the time
             # at which the previous lap was set
@@ -1589,7 +1589,7 @@ class Session:
                             # PitOutTime later if possible
                             laps_start_time[
                                 restart_index
-                            ] = np.timedelta64("NaT")
+                            ] = np.timedelta64("NaT", "ns")
                     elif row["Status"] == "Aborted":  # red flag
                         _is_aborted = True
 
@@ -1923,7 +1923,7 @@ class Session:
                 quali_results = (quali_results
                                  .merge(laps, on="DriverNumber", how="left"))
             else:
-                quali_results[session_name] = np.timedelta64("NaT")
+                quali_results[session_name] = np.timedelta64("NaT", "ns")
 
         quali_results = quali_results \
             .sort_values(by=["Q3", "Q2", "Q1"]) \

--- a/fastf1/tests/test_laps.py
+++ b/fastf1/tests/test_laps.py
@@ -358,7 +358,7 @@ def test_calculated_quali_results(source):
 
     # copy and delete (!) before recalculating
     ergast_results = session.results.copy()
-    session.results.loc[:, ('Q1', 'Q2', 'Q3')] = np.timedelta64("NaT")
+    session.results.loc[:, ('Q1', 'Q2', 'Q3')] = np.timedelta64("NaT", "ns")
 
     if source == "session_status":
         # delete precalculated split times (from api parser)
@@ -370,7 +370,7 @@ def test_calculated_quali_results(source):
     # it was slower than the 107% rule. Calculation excludes it.
     # This needs to be addressed separately with an indication of not classified.
     ergast_results.loc[ergast_results['DriverNumber'] == "21", "Q1"] \
-        = np.timedelta64("NaT")
+        = np.timedelta64("NaT", "ns")
 
     pd.testing.assert_frame_equal(ergast_results, session.results)
 
@@ -397,7 +397,7 @@ def test_quali_q3_cancelled(source):
     # that would be a better test case. The last one was the US GP in 2015, so
     # no lap data is available.
     session.session_status.drop([13, 14, 15, 16], inplace=True)
-    session.results['Q3'] = np.timedelta64("NaT")
+    session.results['Q3'] = np.timedelta64("NaT", "ns")
     if source == "session_status":
         # delete precalculated split times (from api parser)
         session._session_split_times = None
@@ -414,7 +414,7 @@ def test_quali_q3_cancelled(source):
     # Test _calculate_quali_like_session_results()
     # copy and delete (!) before recalculating
     orig_results = session.results.copy()
-    session.results.loc[:, ('Q1', 'Q2', 'Q3')] = np.timedelta64("NaT")
+    session.results.loc[:, ('Q1', 'Q2', 'Q3')] = np.timedelta64("NaT", "ns")
     session._calculate_quali_like_session_results(force=True)
 
     # Note that differences may exist if one or more drivers didn't set a

--- a/pytest.ini
+++ b/pytest.ini
@@ -50,3 +50,5 @@ filterwarnings =
   # older versions of matplotlib, e.g. "'oneOf' deprecated - use 'one_of'"
   # (01/2026)
   ignore:'[a-z]+[A-Z][a-z]+' deprecated - use '[a-z]+_[a-z]+':DeprecationWarning
+  # internal addressed in PR#944; external still triggered by pandas, thus ignore
+  ignore:The 'generic' unit for NumPy timedelta is deprecated:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -50,5 +50,6 @@ filterwarnings =
   # older versions of matplotlib, e.g. "'oneOf' deprecated - use 'one_of'"
   # (01/2026)
   ignore:'[a-z]+[A-Z][a-z]+' deprecated - use '[a-z]+_[a-z]+':DeprecationWarning
-  # internal addressed in PR#944; external still triggered by pandas, thus ignore
+  # internal addressed in PR#945; external still triggered by pandas, thus ignore
+  # (06/2026)
   ignore:The 'generic' unit for NumPy timedelta is deprecated:DeprecationWarning


### PR DESCRIPTION
``numpy.timedelta64(...)`` will require a unit to be specified in the future. Units were only missing for calls that created at ``NaT`` object. These calls now use the "ns" unit which matches the default timedelta unit that is used by pandas.

The warning is addtitionally ignored in pytest since pandas internal code still triggers this warning in all currently supported versions of pandas.

### PR summary
<!-- Please take some time to make it easier for us maintainers to understand
  and review your PR. Describe the pull request in your own words and link to 
  any relevant issues and PRs.

  You should also read [the contribution guide](https://docs.fastf1.dev/contributing/index.html)
  before creating a PR.
-->

#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
  the tool(s) used, how they were used, and specify what code or text is AI generated.
  If no AI tools were used, please write "No AI tools used" in this section. Read our
  policy on AI generated code at
  https://docs.fastf1.dev/contributing/ai_policy.html

  It is especially important that you always interact and communicate as a human. 
  Do not submit fully AI generated pull requests or AI generated pull request descriptions
  or comments.
-->
Claude was used for some background research. All code changes done manually.