### PR TITLE
FIX: accept lap times over 150s that match the sector times (#612)

### DIFF
--- a/docs/changelog/current.rst
+++ b/docs/changelog/current.rst
@@ -34,6 +34,15 @@ New Features
   Previously, both columns were ``NaT``/``NaN`` for these sessions.
 
 
+Bug Fixes
+^^^^^^^^^
+
+- Lap times that are longer than 150 seconds are no longer ignored if they are equal to sector sum.
+  Previously, all lap times above this threshold were discarded, which caused missing lap times during safety car and red flag periods. 
+  In the 2020 British Grand Prix, it also caused the lap time of the previous lap to be used for lap 15
+  of Grosjean, which resulted in a timing integrity error. (#612)
+
+
 What's new in v3.8.3
 --------------------
 

--- a/fastf1/_api.py
+++ b/fastf1/_api.py
@@ -357,6 +357,21 @@ def _get_gap_str_for_drv(drv, idx, laps_data, stream_data):
     return stream_data.loc[ref_idx]["GapToLeader"]
 
 
+def _sector_sum(drv_data, lap_idx):
+    """Sum of the three sector times of a lap.
+
+    Returns None if any of the sector times is missing, i.e. if no
+    complete sum can be calculated.
+    """
+    total = datetime.timedelta(0)
+    for key in ("Sector1Time", "Sector2Time", "Sector3Time"):
+        sector_time = drv_data[key][lap_idx]
+        if pd.isna(sector_time):
+            return None
+        total += sector_time
+    return total
+
+
 def _laps_data_driver(driver_raw, empty_vals, drv):
     """
     .. warning::
@@ -466,14 +481,21 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
             # missing or if the value is an empty string
 
             val = to_timedelta(val)  # empty string converts to None here!
+            lap_idx = lapcnt - lap_offset
             # Set None values too, to explicitly differentiate the case where
             # no information about the value is found in the source from the
             # case here where the source indicates that no value exists.
-            if (val is None) or (val.total_seconds() < 150):
-                # laps which are longer than 150 seconds are ignored; usually this is the case between Q1, Q2 and Q3
-                # because all three qualifying sessions are one session here. Those timestamps are often wrong and
-                # sometimes associated with the wrong lap
-                drv_data["LapTime"][lapcnt - lap_offset] = val
+            if ((val is None) or (val.total_seconds() < 150)
+                    or (val == _sector_sum(drv_data, lap_idx))):
+                # Lap times longer than 150 seconds are usually incorrect:
+                # because all three qualifying sessions are one session here,
+                # the value that is received between Q1, Q2 and Q3 is the time
+                # since the driver's previous lap. Those values are often wrong
+                # and sometimes associated with the wrong lap. Such a value is
+                # only accepted if the sector times that were received for this
+                # lap add up to exactly the same value, which identifies it as
+                # a genuinely slow lap (e.g. safety car or red flag).
+                drv_data["LapTime"][lap_idx] = val
 
         if "Speeds" in resp:
             for trapkey, trapname in (("I1", "SpeedI1"), ("I2", "SpeedI2"), ("FL", "SpeedFL"), ("ST", "SpeedST")):

--- a/fastf1/tests/test_input_data_handling.py
+++ b/fastf1/tests/test_input_data_handling.py
@@ -283,6 +283,39 @@ def test_explicitly_missing_lap_times_calculated():
 
 
 @pytest.mark.f1telapi
+def test_long_lap_time_accepted_if_sector_times_match():
+    # Grosjean's lap 15 in the 2020 British GP took longer than 150 seconds
+    # because of a safety car period. The source data additionally contains
+    # the lap time of lap 14 a second time, received after the lap count had
+    # already been increased. Previously, the correct value for lap 15 was
+    # discarded because it exceeded the 150 second threshold, so that the
+    # duplicated value of lap 14 was used for lap 15 as well. This caused a
+    # timing integrity error. The sector times of lap 15 add up to exactly
+    # the correct lap time, which identifies it as a genuine lap. (GH#612)
+    session = fastf1.get_session(2020, 4, 'R')
+    session.load(telemetry=False, weather=False)
+    gro = session.laps.pick_drivers('8')
+
+    assert gro.pick_laps(15)['LapTime'].iloc[0] \
+           == pd.Timedelta(seconds=151.069)
+    assert gro.pick_laps(14)['LapTime'].iloc[0] \
+           != gro.pick_laps(15)['LapTime'].iloc[0]
+
+
+@pytest.mark.f1telapi
+def test_incorrect_long_lap_times_ignored_in_qualifying():
+    # Because Q1, Q2 and Q3 are a single session in the source data, the API
+    # sends the time since the driver's previous lap as lap time between the
+    # individual parts of qualifying. Those values are incorrect and need to
+    # be ignored, even though lap times longer than 150 seconds are accepted
+    # if they match the sector times of the lap. (GH#612)
+    session = fastf1.get_session(2023, 'Canada', 'Q')
+    session.load(telemetry=False, weather=False)
+
+    assert session.laps['LapTime'].max() < pd.Timedelta(minutes=5)
+
+
+@pytest.mark.f1telapi
 @pytest.mark.parametrize(
     "year, round_, session, drv, stints",
     (


### PR DESCRIPTION
### PR summary
The 150s lap-time cap can't tell a genuine slow lap from a Q-segment artifact i.e. start times of (sub)sessions (Q1, Q2, Q3), so that means real lap times get dropped, this can be seen in GRO lap 15 during the 2020 British GP. So instead of just discarding the lap, it now accepts a lap >150s value only when it exactly equals that lap's sector sum i.e sec1 + sec 2 + sec 3.

This works because it's the same timing loops, with integer-nanosecond timedeltas and no float error
When I implemented it, it resulted in 91 lap times recovered, 0 lost, 0 changed across 4 sessions
The new test fails on master but it passes with the fix
Another thing to note that test_quali_q3_cancelled already fails on master, unrelated to this PR

#### AI Disclosure
I used Claude Code for investigation of the source data and parser, the implementation, and the tests.
I did the review, verification, and this description.
