### PR TITLE
FIX: correct handling of not classified drivers in quali results

### DIFF
--- a/docs/changelog/current.rst
+++ b/docs/changelog/current.rst
@@ -10,6 +10,23 @@ Removals
   was deprecated in v3.0.0 because it produced inaccurate results (#884).
 
 
+Behaviour Changes
+^^^^^^^^^^^^^^^^^
+
+- Changes to ``Session.results`` for Qualifying and Sprint Qualifying:
+    - If a driver was eliminated in Q1 and did not pass the 107% rule, their
+      best Q1 time will now be **included** in the result.
+    - The "ClassifiedPosition" column will be populated with the drivers'
+      respective classified positions. If a driver was eliminated in Q1, the
+      value will be set to "N" for "Not Classified".
+    - The old behaviour was for the "ClassifiedPosition" column to not be
+      used. Drivers who failed the 107% rule had their time excluded from the
+      results. The new behaviour follows partially from a change in the data
+      that is returned by the Jolpica-F1 API. Further, the new behaviour
+      provides more informative data and better matches the behaviour that
+      was already described in the documentation.
+
+
 Deprecations
 ^^^^^^^^^^^^
 

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -1917,7 +1917,6 @@ class Session:
         for i, session in enumerate(sessions):
             session_name = f"Q{i + 1}"
             if session is not None:
-                session = session.pick_quicklaps()  # 107% rule applies per Q
                 laps = (
                     session[~session["LapTime"].isna() & ~session["Deleted"]]
                     .copy()
@@ -1935,6 +1934,15 @@ class Session:
             .sort_values(by=["Q3", "Q2", "Q1"]) \
             .reset_index(drop=True)
         quali_results["Position"] = (quali_results.index + 1).astype("float64")
+
+        # augment not classified based on 107% rule
+        fastest_q1 = quali_results["Q1"].min()
+        eliminated = quali_results["Q2"].isna()
+        nc = (quali_results["Q1"] > (fastest_q1 * 1.07)) & eliminated
+        c_pos = quali_results["Position"].astype(str)
+        c_pos.loc[nc] = "N"
+        quali_results["ClassifiedPosition"] = c_pos
+
         quali_results = quali_results.set_index("DriverNumber", drop=True)
 
         self.results.loc[:, quali_results.columns] = quali_results
@@ -2508,6 +2516,16 @@ class Session:
 
         if "Position" in self._results:
             self._results = self._results.sort_values("Position")
+
+        if self.name == "Qualifying":
+            # augment not classified based on 107% rule;
+            # old Ergast API does not provide this info
+            fastest_q1 = self._results["Q1"].min()
+            eliminated = self._results["Q2"].isna()
+            nc = (self._results["Q1"] > (fastest_q1 * 1.07)) & eliminated
+            c_pos = self._results["Position"].astype(str)
+            c_pos.loc[nc] = "N"
+            self._results["ClassifiedPosition"] = c_pos
 
     def _drivers_from_f1_api(self, *, livedata=None):
         try:


### PR DESCRIPTION
### PR summary
**Now:**

 - If a driver was eliminated in Q1 and did not pass the 107% rule, their
   best Q1 time will now be **included** in the result.
- The "ClassifiedPosition" column will be populated with the drivers'
  respective classified positions. If a driver was eliminated in Q1, the
  value will be set to "N" for "Not Classified".

**Previously:**

The old behaviour was for the "ClassifiedPosition" column to not be
used. Drivers who failed the 107% rule had their time excluded from the
results. The new behaviour follows partially from a change in the data
that is returned by the Jolpica-F1 API. 


**Why the behaviour change:**

- Data from the Jolpica-F1 API previously did not include times stamps for not classified drivers. This has changed recently.
- The old behaviour is not documented. The time stamp is simply missing if a driver is not classified.
- The documentation for "ClassifiedPosition" does not state that the column is only used for race like sessions.

Overall, a new user would be likely to assume that the new behaviour is the expected behaviour.


#### AI Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
  the tool(s) used, how they were used, and specify what code or text is AI generated.
  If no AI tools were used, please write "No AI tools used" in this section. Read our
  policy on AI generated code at
  https://docs.fastf1.dev/contributing/ai_policy.html

  It is especially important that you always interact and communicate as a human. 
  Do not submit fully AI generated pull requests or AI generated pull request descriptions
  or comments.
-->
No AI tools used