### PR TITLE
MNT: enable ruff PD rules, except PD010

### DIFF
--- a/examples/standings/plot_results_tracker.py
+++ b/examples/standings/plot_results_tracker.py
@@ -29,10 +29,10 @@ for rnd, race in races["raceName"].items():
     # If there is a sprint, get the results as well
     sprint = ergast.get_sprint_results(season=2022, round=rnd + 1)
     if sprint.content and sprint.description["round"][0] == rnd + 1:
-        temp = pd.merge(temp, sprint.content[0], on="driverCode", how="left")
+        temp = temp.merge(sprint.content[0], on="driverCode", how="left")
         # Add sprint points and race points to get the total
         temp["points"] = temp["points_x"] + temp["points_y"]
-        temp.drop(columns=["points_x", "points_y"], inplace=True)
+        temp = temp.drop(columns=["points_x", "points_y"])
 
     # Add round no. and grand prix name
     temp["round"] = rnd + 1
@@ -47,13 +47,15 @@ races = results["race"].drop_duplicates()
 ##############################################################################
 # Then we “reshape” the results to a wide table, where each row represents a
 # driver and each column refers to a race, and the cell value is the points.
-results = results.pivot(index="driverCode", columns="round", values="points")
+results = results.pivot(  # noqa: PD010
+    index="driverCode", columns="round", values="points"
+)
 # Here we have a 22-by-22 matrix (22 races and 22 drivers, incl. DEV and HUL)
 
 # Rank the drivers by their total points
 results["total_points"] = results.sum(axis=1)
 results = results.sort_values(by="total_points", ascending=False)
-results.drop(columns="total_points", inplace=True)
+results = results.drop(columns="total_points")
 
 # Use race name, instead of round no., as column names
 results.columns = races

--- a/examples/standings/plot_season_summary.py
+++ b/examples/standings/plot_season_summary.py
@@ -55,9 +55,9 @@ for _, event in schedule.iterrows():
                 sprint.results["Abbreviation"] == abbreviation
             ]
             if not driver_row.empty:
-                # We need the values[0] accessor because driver_row is actually
+                # We need the [0] accessor because driver_row is actually
                 # returned as a dataframe with a single row
-                sprint_points = driver_row["Points"].values[0]
+                sprint_points = driver_row["Points"].to_numpy()[0]
 
         standings.append(
             {
@@ -79,7 +79,7 @@ df = pd.DataFrame(standings)
 # We remake it into an easier to use format where the row indices are the
 # drivers, and the columns are the races. This allows us to look up the points
 # scored by a driver at a race more easily.
-heatmap_data = df.pivot(
+heatmap_data = df.pivot(  # noqa: PD010
     index="Driver", columns="RoundNumber", values="Points"
 ).fillna(0)
 
@@ -87,11 +87,11 @@ heatmap_data = df.pivot(
 # scoring driver is towards the bottom
 heatmap_data["total_points"] = heatmap_data.sum(axis=1)
 heatmap_data = heatmap_data.sort_values(by="total_points", ascending=True)
-total_points = heatmap_data["total_points"].values
+total_points = heatmap_data["total_points"].to_numpy()
 heatmap_data = heatmap_data.drop(columns=["total_points"])
 
 # Do the same for position.
-position_data = df.pivot(
+position_data = df.pivot(  # noqa: PD010
     index="Driver", columns="RoundNumber", values="Position"
 ).fillna("N/A")
 
@@ -100,7 +100,7 @@ position_data = df.pivot(
 hover_info = [
     [
         {
-            "position": position_data.at[driver, race],
+            "position": position_data.loc[driver, race],
         }
         for race in schedule["RoundNumber"]
     ]
@@ -141,7 +141,7 @@ fig.add_trace(
         zmin=0,
         # We need to set zmax for the two heatmaps separately as the
         # max value in the total points plot is significantly higher.
-        zmax=heatmap_data.values.max(),
+        zmax=heatmap_data.to_numpy().max(),
     ),
     row=1,
     col=1,

--- a/fastf1/_api.py
+++ b/fastf1/_api.py
@@ -26,7 +26,7 @@ base_url_mirror = "https://livetiming-mirror.fastf1.dev"
 
 headers: dict[str, str] = {
     "Connection": "close",
-    "TE": "identity",
+    "TE": "identity",  # codespell:ignore
     "User-Agent": "BestHTTP",
     "Accept-Encoding": "gzip, identity",
 }
@@ -253,7 +253,7 @@ def _extended_timing_data(path, response=None, livedata=None):
                  logger=_logger)
 def _align_laps(laps_data, stream_data):
     # align lap start and end times between drivers based on Gap to leader
-    if pd.isnull(stream_data["GapToLeader"]).all():
+    if pd.isna(stream_data["GapToLeader"]).all():
         return  # no data to align on
 
     expected_gap = {}
@@ -272,8 +272,8 @@ def _align_laps(laps_data, stream_data):
         skip_drivers = laps_data.loc[
             (
                 (laps_data["NumberOfLaps"] == (offset + 1)) &
-                ((~pd.isnull(laps_data["PitInTime"])) |
-                 (~pd.isnull(laps_data["PitOutTime"])))
+                ((~pd.isna(laps_data["PitInTime"])) |
+                 (~pd.isna(laps_data["PitOutTime"])))
             ), "Driver"
         ].to_list()
 
@@ -543,7 +543,7 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
     def data_in_lap(lap_n):
         relevant = ("Sector1Time", "Sector2Time", "Sector3Time", "SpeedI1", "SpeedI2",
                     "SpeedFL", "SpeedST", "LapTime")
-        return any(not pd.isnull(drv_data[col][lap_n]) for col in relevant)
+        return any(not pd.isna(drv_data[col][lap_n]) for col in relevant)
 
     # 'NumberOfLaps' always introduces a new lap (can be a previous one) but sometimes there is one more lap at the end
     # in this case the data will be added as usual above, lap count and pit stops are added here and the 'Time' is
@@ -634,14 +634,14 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
         for sector_time, session_time in ((pd.Timedelta(0), drv_data["Sector3SessionTime"][i]),
                                           (drv_data["Sector3Time"][i], drv_data["Sector2SessionTime"][i]),
                                           (drv_data["Sector2Time"][i], drv_data["Sector1SessionTime"][i])):
-            if pd.isnull(session_time):
+            if pd.isna(session_time):
                 continue
-            if pd.isnull(sector_time):
+            if pd.isna(sector_time):
                 break  # need to stop here because else the sector sum will be incorrect
 
             sector_sum += sector_time
             new_time = session_time + sector_sum
-            if not pd.isnull(new_time) and (new_time < min_time or pd.isnull(min_time)):
+            if not pd.isna(new_time) and (new_time < min_time or pd.isna(min_time)):
                 min_time = new_time
         if i > 0 and min_time < drv_data["Time"][i - 1]:
             integrity_errors.append(i + 1)  # not be possible if sector times and lap time are correct
@@ -650,8 +650,8 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
         drv_data["Time"][i] = min_time
 
     # last lap needs to be removed if it does not have a 'Time' and it could not be calculated (likely an inlap)
-    if pd.isnull(drv_data["Time"][-1]):
-        if not pd.isnull(drv_data["PitInTime"][-1]):
+    if pd.isna(drv_data["Time"][-1]):
+        if not pd.isna(drv_data["PitInTime"][-1]):
             drv_data["Time"][-1] = drv_data["PitInTime"][-1]
         else:
             for key in drv_data:
@@ -672,8 +672,8 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
 
     # need to go both directions once to make everything match up; also recalculate sector times
     for i in range(len(drv_data["Time"]) - 1):
-        if (pd.isnull(drv_data["Time"][i])
-                or pd.isnull(drv_data["LapTime"][i + 1])):
+        if (pd.isna(drv_data["Time"][i])
+                or pd.isna(drv_data["LapTime"][i + 1])):
             # lap not usable, missing critical values; more checks follow
             continue
 
@@ -681,7 +681,7 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
                 < drv_data["Time"][i+1]:
             drv_data["Time"][i+1] = new_time
 
-        if pd.isnull(drv_data["Sector1Time"][i + 1]):
+        if pd.isna(drv_data["Sector1Time"][i + 1]):
             continue
 
         if (new_s1_time := drv_data["Time"][i]
@@ -689,7 +689,7 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
                 < drv_data["Sector1SessionTime"][i+1]:
             drv_data["Sector1SessionTime"][i+1] = new_s1_time
 
-        if pd.isnull(drv_data["Sector2Time"][i + 1]):
+        if pd.isna(drv_data["Sector2Time"][i + 1]):
             continue
 
         if (new_s2_time := drv_data["Time"][i] + drv_data["Sector1Time"][i+1]
@@ -697,7 +697,7 @@ def _laps_data_driver(driver_raw, empty_vals, drv):
                 < drv_data["Sector2SessionTime"][i+1]:
             drv_data["Sector2SessionTime"][i+1] = new_s2_time
 
-        if pd.isnull(drv_data["Sector3Time"][i + 1]):
+        if pd.isna(drv_data["Sector3Time"][i + 1]):
             continue
 
         if (new_s3_time := drv_data["Time"][i] + drv_data["Sector1Time"][i+1]

--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -214,7 +214,8 @@ class Telemetry(BaseDataFrame):
 
         if drop_unknown_channels:
             unknown = set(self.columns).difference(self._CHANNELS.keys())
-            super().drop(columns=unknown, inplace=True)
+            # `self` cannot be rebound here, so the drop must be inplace
+            super().drop(columns=unknown, inplace=True)  # noqa: PD002
             if unknown:
                 _logger.warning(
                     f"The following unknown telemetry channels have "
@@ -927,13 +928,13 @@ class Telemetry(BaseDataFrame):
         )
 
         if ((d["Date"].shape != dtd["Date"].shape)
-                or np.any(d["Date"].values
-                          != dtd["Date"].values)):
+                or np.any(d["Date"].to_numpy()
+                          != dtd["Date"].to_numpy())):
             dtd = dtd.resample_channels(new_date_ref=d["Date"])
 
         # indices need to match as .join works index-on-index
         dtd["_SelfIndex"] = d.index
-        dtd.set_index("_SelfIndex", drop=True, inplace=True)
+        dtd = dtd.set_index("_SelfIndex", drop=True)
 
         return d.join(dtd.loc[:, ("DriverAhead", "DistanceToDriverAhead")],
                       how="outer")
@@ -1468,7 +1469,7 @@ class Session:
         # Matching data and app_data. Not super straightforward
         # Sometimes a car may enter the pit without changing tyres, so
         # new compound is associated with the help of logging time.
-        data.drop(columns=["NumberOfPitStops"], inplace=True)
+        data = data.drop(columns=["NumberOfPitStops"])
         useful = app_data[["Driver", "Time", "Compound", "StartLaps", "New",
                            "Stint"]]
 
@@ -1498,7 +1499,7 @@ class Session:
                 # Find all laps where a driver went into the pits. Their end
                 # times mark the end of each stint.
                 stint_split_times = d1.loc[
-                    ~pd.isnull(d1["PitInTime"]), "Time"
+                    ~pd.isna(d1["PitInTime"]), "Time"
                 ].to_list()
 
                 d2 = self.__fix_tyre_info(d2, stint_split_times)
@@ -1520,7 +1521,7 @@ class Session:
                     # for drivers who could not start the race
                     is_generated = True
                     result = d1.copy()
-                    result.reset_index(drop=True, inplace=True)
+                    result = result.reset_index(drop=True)
                     result["Driver"] = [driver, ]
                     result["NumberOfLaps"] = 1
                     result["Time"] = data["Time"].min()
@@ -1535,7 +1536,7 @@ class Session:
 
             elif not len(d2):
                 result = d1.copy()
-                result.reset_index(drop=True, inplace=True)
+                result = result.reset_index(drop=True)
                 result["Compound"] = ""
                 result["TyreLife"] = np.nan
                 result["Stint"] = 0
@@ -1618,9 +1619,9 @@ class Session:
         laps = df.reset_index(drop=True)
 
         # rename some columns
-        laps.rename(columns={"Driver": "DriverNumber",
-                             "NumberOfLaps": "LapNumber",
-                             "New": "FreshTyre"}, inplace=True)
+        laps = laps.rename(columns={"Driver": "DriverNumber",
+                                    "NumberOfLaps": "LapNumber",
+                                    "New": "FreshTyre"})
 
         laps["Stint"] += 1  # counting stints from 1
 
@@ -1680,7 +1681,7 @@ class Session:
 
             # forward fill finish line speed trap like sector 1 speed trap,
             # additionally excluding laps where the driver entered the pits
-            appl_mask &= pd.isnull(laps.loc[drv_mask, "PitInTime"])
+            appl_mask &= pd.isna(laps.loc[drv_mask, "PitInTime"])
             fill_fl = laps.loc[drv_mask, "SpeedFL"].ffill().loc[appl_mask]
             laps.loc[appl_mask & drv_mask, "SpeedFL"] = fill_fl
 
@@ -1946,7 +1947,7 @@ class Session:
         quali_results = quali_results.set_index("DriverNumber", drop=True)
 
         self.results.loc[:, quali_results.columns] = quali_results
-        self.results.sort_values(by=["Position"], inplace=True)
+        self._results = self._results.sort_values(by=["Position"])
 
     @soft_exceptions(
         "practice results",
@@ -1997,7 +1998,7 @@ class Session:
         self.results.loc[:, ["Time", "Position"]] = (
             best_laps[["Time", "Position"]]
         )
-        self.results.sort_values(by=["Position"], inplace=True)
+        self._results = self._results.sort_values(by=["Position"])
 
     @soft_exceptions(
         "race results",
@@ -2054,7 +2055,7 @@ class Session:
         final_order["Position"] = (final_order.index + 1).astype("float64")
         final_order = final_order.set_index("DriverNumber")
         self.results.loc[:, ["Position"]] = final_order["Position"]
-        self.results.sort_values(by=["Position"], inplace=True)
+        self._results = self._results.sort_values(by=["Position"])
 
     @soft_exceptions("add track status to laps",
                      "Failed to add track status to Laps!",
@@ -2346,15 +2347,15 @@ class Session:
                 lap_integrity_ok = True
                 # require existence, non-existence and specific values for
                 # some variables
-                check_1 = (pd.isnull(lap["PitInTime"])
-                           & pd.isnull(lap["PitOutTime"])
+                check_1 = (pd.isna(lap["PitInTime"])
+                           & pd.isna(lap["PitOutTime"])
                            & (not lap["FastF1Generated"])
                            # slightly paranoid, allow only green + yellow flag
                            & (lap["TrackStatus"] in ("1", "2", "12", "21"))
-                           & (not pd.isnull(lap["LapTime"]))
-                           & (not pd.isnull(lap["Sector1Time"]))
-                           & (not pd.isnull(lap["Sector2Time"]))
-                           & (not pd.isnull(lap["Sector3Time"])))
+                           & (not pd.isna(lap["LapTime"]))
+                           & (not pd.isna(lap["Sector1Time"]))
+                           & (not pd.isna(lap["Sector2Time"]))
+                           & (not pd.isna(lap["Sector3Time"])))
 
                 if check_1:
                     # only do check 2 if all necessary values for this check
@@ -2379,10 +2380,10 @@ class Session:
                 else:
                     check_3 = True  # no previous lap, no SC error
 
-                pre_check_4 = (((not pd.isnull(lap["Time"]))
-                               & (not pd.isnull(lap["LapTime"])))
+                pre_check_4 = (((not pd.isna(lap["Time"]))
+                               & (not pd.isna(lap["LapTime"])))
                                and (prev_lap is not None)
-                               and (not pd.isnull(prev_lap["Time"])))
+                               and (not pd.isna(prev_lap["Time"])))
 
                 if pre_check_4:  # needed condition for check_4
                     time_diff = np.sum((lap["Time"],
@@ -2675,9 +2676,7 @@ class Session:
         if load_drivers:
             d["FullName"] = d["FirstName"] + " " + d["LastName"]
 
-        d.set_index("DriverNumber", drop=False, inplace=True)
-
-        return d
+        return d.set_index("DriverNumber", drop=False)
 
     @soft_exceptions("weather data", "Failed to load weather data!", _logger)
     def _load_weather_data(self, livedata=None):
@@ -3449,8 +3448,8 @@ class Laps(BaseDataFrame):
         Returns:
             instance of :class:`Laps`
         """
-        return self[pd.isnull(self["PitInTime"])
-                    & pd.isnull(self["PitOutTime"])]
+        return self[pd.isna(self["PitInTime"])
+                    & pd.isna(self["PitOutTime"])]
 
     def pick_box_laps(self, which: str = "both") -> "Laps":
         """Return all laps which are either in-laps, out-laps, or both.
@@ -3471,12 +3470,12 @@ class Laps(BaseDataFrame):
             instance of :class:`Laps`
         """
         if which == "in":
-            return self[~pd.isnull(self["PitInTime"])]
+            return self[~pd.isna(self["PitInTime"])]
         if which == "out":
-            return self[~pd.isnull(self["PitOutTime"])]
+            return self[~pd.isna(self["PitOutTime"])]
         if which == "both":
-            return self[~pd.isnull(self["PitInTime"])
-                        | ~pd.isnull(self["PitOutTime"])]
+            return self[~pd.isna(self["PitInTime"])
+                        | ~pd.isna(self["PitOutTime"])]
         raise ValueError(f"Invalid value '{which}' for kwarg 'which'")
 
     def pick_not_deleted(self) -> "Laps":
@@ -3599,7 +3598,7 @@ class Laps(BaseDataFrame):
         Args:
             require: Require is a list of column/telemetry channel names. All
                 names listed in `require` must exist in the data and have a
-                non-null value (tested with :func:`pandas.is_null`). The
+                non-null value (tested with :func:`pandas.isna`). The
                 iterator only yields laps for which this is true. If require is
                 left empty, the iterator will yield all laps.
         Yields:
@@ -3608,10 +3607,10 @@ class Laps(BaseDataFrame):
         for index, lap in self.iterrows():
             if require:
                 # make sure that all required values even exist in the index
-                if any(val not in lap.index.values for val in require):
+                if any(val not in lap.index.to_numpy() for val in require):
                     continue
-                require = set(require).intersection(set(lap.index.values))
-                if any(pd.isnull(val) for val in lap.loc[require]):
+                require = set(require).intersection(set(lap.index.to_numpy()))
+                if any(pd.isna(val) for val in lap.loc[require]):
                     continue
             yield index, lap
 

--- a/fastf1/events.py
+++ b/fastf1/events.py
@@ -971,7 +971,7 @@ class Event(BaseSeries):
         _name = mask.idxmax()
         date_utc = self[f"{_name}DateUtc"]
         date = self[f"{_name}Date"]
-        if (not utc) and pd.isnull(date) and (not pd.isnull(date_utc)):
+        if (not utc) and pd.isna(date) and (not pd.isna(date_utc)):
             raise ValueError("Local timestamp is not available")
         if utc:
             return date_utc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ select = [
     "ARG",
     "RUF100",
     "Q",
+    "PD",
 ]
 
 ignore = [


### PR DESCRIPTION
### PR summary

Enables the `PD` (pandas-vet) ruleset from #741, with `PD010` left for a follow-up
PR as discussed there.

All 58 findings are resolved: PD003 (35), PD002 (12), PD011 (6), PD015 (1) and
PD008 (1). The three PD010 occurrences carry a `# noqa: PD010` so the rule can be
enabled now and new violations can't slip in; the follow-up PR will settle whether
they become a permanent ignore.

Two PD002 cases are worth a look:

- `core.py:217` keeps `inplace=True` with a documented `# noqa`. It's
  `super().drop(...)` inside `Telemetry.__init__` mutating `self` during
  construction, so rebinding wouldn't be equivalent.
- The three `self.results.sort_values(..., inplace=True)` calls became
  `self._results = self._results.sort_values(...)`. I wanted to assign through the
  public attribute, but `Session.results` is a read-only property, so that raises
  `AttributeError`. The call sites are inside the private
  `_calculate_*_session_results` methods, which already assign and read
  `self._results` directly, and `BaseDataFrame._constructor` returns
  `self.__class__`, so the result is still a `SessionResults`.

Removing `inplace=True` at `core.py:2660` surfaced a RET504, fixed by returning the
expression directly.

Two changes go slightly beyond what the rules require, both easy to drop if you'd
rather keep the diff minimal:

- `core.py` has two adjacent `lap.index.values` uses in `iterlaps` and Ruff only
  flags the first. I converted both, since leaving one behind looked odd.
- The pre-commit codespell hook flags the `TE` HTTP header in `_api.py`, which
  this PR touches, so it now carries an inline `# codespell:ignore`.

Following the discussion in #959, the `iterlaps` docstring also referenced
`pandas.is_null`, which doesn't exist under that name, so it now points at
`pandas.isna`. It was the only such reference in the repository.

### Verification

Loaded the 2024 Bahrain race, qualifying and FP1 from the API and compared results
order, positions, frame types, lap counts, compounds, tyre data and a full
telemetry merge against an unmodified checkout: identical. Both modified gallery
examples were executed end to end and their output frames compared the same way.

`ruff check .` and `isort --check-only .` are clean. `test_core.py`,
`test_telemetry.py` and `test_internals.py` pass locally.

Note that `main` is currently failing CI on all Python versions, and
`test_quali_q3_cancelled` fails identically with and without this change.

### Unrelated finding

Opened as #959: `Laps.iterlaps(require=...)` raises
`TypeError: Passing a set as an indexer is not supported`, because `require` is
converted to a set before being passed to `.loc`. Not addressed in this PR.

### AI Disclosure

I used Claude Code for the mechanical parts of this change, including the `pd.isnull` → `pd.isna` replacements, the straightforward `inplace=True` rewrites, and the `.values` / `.at` / `pd.merge` conversions.

The `# noqa: PD002` for `core.py:217` was my own analysis, which I posted in #741 before making any changes.

For the three `self.results.sort_values(...)` cases, I also used Claude Code to help work through the implementation. The final approach was based on checking that `Session.results` is read-only, that these call sites already work directly with `self._results`, and that `BaseDataFrame._constructor` preserves the `SessionResults` subclass.

The before/after comparisons and tests described above were run as part of the verification.

I reviewed the full diff and all changes in the PR.

