### PR TITLE
FIX: Laps.iterlaps(require=...) raises a TypeError

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -3604,12 +3604,14 @@ class Laps(BaseDataFrame):
         Yields:
             (index, lap): label and an instance of :class:`Lap`
         """
+        if require is not None:
+            require = list(require)
+
         for index, lap in self.iterrows():
             if require:
                 # make sure that all required values even exist in the index
                 if any(val not in lap.index.to_numpy() for val in require):
                     continue
-                require = set(require).intersection(set(lap.index.to_numpy()))
                 if any(pd.isna(val) for val in lap.loc[require]):
                     continue
             yield index, lap

--- a/fastf1/tests/test_laps.py
+++ b/fastf1/tests/test_laps.py
@@ -64,6 +64,46 @@ def test_dtypes_default_columns():
     ensure_data_type(LAP_DTYPES, laps)
 
 
+def _laps_with_one_missing_lap_time():
+    return fastf1.core.Laps({
+        'LapNumber': (1.0, 2.0, 3.0),
+        'LapTime': (pd.Timedelta(seconds=90), pd.NaT,
+                    pd.Timedelta(seconds=92))
+    })
+
+
+@pytest.mark.parametrize('iterable_type', (tuple, list, set, frozenset))
+def test_iterlaps_require(iterable_type):
+    laps = _laps_with_one_missing_lap_time()
+
+    # laps that hold a null value in a required column are skipped
+    lap_numbers = []
+    for _, lap in laps.iterlaps(require=iterable_type(('LapTime',))):
+        lap_numbers.append(lap['LapNumber'])
+    assert lap_numbers == [1.0, 3.0]
+
+    # a required column that does not exist skips every lap
+    require = iterable_type(('LapTime', 'NotAColumn'))
+    assert not list(laps.iterlaps(require=require))
+
+    # without `require`, every lap is yielded
+    assert len(list(laps.iterlaps())) == 3
+
+
+def test_iterlaps_require_single_use_iterator():
+    laps = _laps_with_one_missing_lap_time()
+
+    # The check for missing column names iterates `require` and would exhaust a
+    # single-use iterator, leaving nothing for the null value check that
+    # follows it. `require` therefore needs to be materialized beforehand.
+    single_use_iterator = iter(('LapTime',))
+
+    lap_numbers = []
+    for _, lap in laps.iterlaps(require=single_use_iterator):
+        lap_numbers.append(lap['LapNumber'])
+    assert lap_numbers == [1.0, 3.0]
+
+
 @pytest.mark.f1telapi
 def test_dtypes_pick(reference_laps_data):
     session, laps = reference_laps_data


### PR DESCRIPTION
### PR summary

Closes #959.

`Laps.iterlaps(require=...)` currently raises `TypeError: Passing a set as an indexer is not supported` on the first lap, because `require` is converted to a set and that set is then passed to `.loc`.

The set conversion is not actually needed. The check immediately above already skips any lap that is missing one of the required columns, so by the time the intersection is reached, `require` is guaranteed to only contain values from the lap index. I verified this against the 2024 Bahrain race data with several different `require` combinations before removing the line.

This also fixes a smaller issue with `require` being reassigned inside the loop. The argument is now materialised once before iterating, so it keeps the value passed by the caller throughout the function. This also means that single-use iterables work correctly instead of being consumed by the first existence check.

### Test

Added `test_iterlaps_require` covering the behaviour described in the docstring:

* laps with null values in required columns are skipped
* any iterable can be passed as `require`
* a missing required column skips all laps
* omitting `require` returns all laps

The test builds a `Laps` object directly, so it does not require session data and runs in well under a second.

The test fails on `main` with the original `TypeError` and passes with this change.

### Note on #958

Rebased onto `main` now that #958 has been merged. The overlap was the deleted set intersection against that PR's `pd.isnull` → `pd.isna` change on the following line.

#### AI Disclosure

I used Claude Code while investigating this issue as part of #958. It helped surface the bug and produced the initial diff and test. I also used it to run the measurement against 1129 laps from the 2024 Bahrain race with seven different require combinations.

I reviewed the resulting changes, reproduced the failure on main, and verified that the test passes with the fix.

