### PR TITLE
MNT: document why PD010 is ignored in the standings examples

### DIFF
--- a/examples/standings/plot_results_tracker.py
+++ b/examples/standings/plot_results_tracker.py
@@ -47,7 +47,7 @@ races = results["race"].drop_duplicates()
 ##############################################################################
 # Then we “reshape” the results to a wide table, where each row represents a
 # driver and each column refers to a race, and the cell value is the points.
-results = results.pivot(  # noqa: PD010
+results = results.pivot(  # noqa: PD010 (pivot must raise on duplicates)
     index="driverCode", columns="round", values="points"
 )
 # Here we have a 22-by-22 matrix (22 races and 22 drivers, incl. DEV and HUL)

--- a/examples/standings/plot_season_summary.py
+++ b/examples/standings/plot_season_summary.py
@@ -79,7 +79,7 @@ df = pd.DataFrame(standings)
 # We remake it into an easier to use format where the row indices are the
 # drivers, and the columns are the races. This allows us to look up the points
 # scored by a driver at a race more easily.
-heatmap_data = df.pivot(  # noqa: PD010
+heatmap_data = df.pivot(  # noqa: PD010 (pivot must raise on duplicates)
     index="Driver", columns="RoundNumber", values="Points"
 ).fillna(0)
 
@@ -91,7 +91,7 @@ total_points = heatmap_data["total_points"].to_numpy()
 heatmap_data = heatmap_data.drop(columns=["total_points"])
 
 # Do the same for position.
-position_data = df.pivot(  # noqa: PD010
+position_data = df.pivot(  # noqa: PD010 (pivot must raise on duplicates)
     index="Driver", columns="RoundNumber", values="Position"
 ).fillna("N/A")
 


### PR DESCRIPTION
### PR summary

Follow-up to #958, which enabled the `PD` ruleset and left the three `PD010`
occurrences marked with a bare `# noqa` while we settled how to handle them.

Having checked it, I'd rather keep `pivot()` here, so this just documents why the
rule is ignored at those three call sites, in the same style as the other `# noqa`
comments in the codebase:

```python
results = results.pivot(  # noqa: PD010 (pivot must raise on duplicates)
```

The reasoning, in short: these examples build a driver-by-round grid, where two
values landing in the same cell would mean something went wrong further upstream.
`pivot` raises in that case, while `pivot_table` would quietly average them. The
pandas docs also present the two as separate tools rather than an older and a
preferred one, describing `pivot_table` as a "generalization of pivot that can
handle duplicate values for one index/column pair".

For the record, the migration to `pivot_table` does work. I ran both examples end
to end with it and the frames they plot come out identical, and none of the three
call sites has duplicate index/column pairs today. It just doesn't seem like the
right function for a reshape in code that people read as an example.

### AI Disclosure

I used Claude Code to run the comparison between `pivot` and `pivot_table` across
both examples, and to apply this diff, which is three comments. The reasoning and
the decision are mine.
